### PR TITLE
save all tasks history and continue after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.0 - 2024-0x-xx]
+## [0.0.2 - 2024-03-20]
 
-- First release, although there is a lot missing - it works.
+- Persistent task history, polished UI, `6` working and useful workflows.
+
+## [0.0.1 - 2024-03-12]
+
+- First release, although there is a lot missing the concept - is working.


### PR DESCRIPTION
After this we can work on running ComfyUI processing in our process and not spawning a separate process for that.

This will much better allow us to handle errors and still be compatible with Comfy :)