### PR TITLE
fix: ask only for tasks that `Vix` instance can handle

### DIFF
--- a/scripts/easy_install.py
+++ b/scripts/easy_install.py
@@ -101,6 +101,10 @@ def install_all_flows():
         "photomaker_1",
         "juggernaut_lighting_loras",
         "stable_cascade",
+        "photo_stickers",
+        "ghibli_portrait",
+        "comicu_portrait",
+        "vintage_portrait"
     ]
 
     for i in flows:

--- a/visionatrix/backend.py
+++ b/visionatrix/backend.py
@@ -60,7 +60,7 @@ def vix_backend(
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
-        await start_tasks_engine(tasks_files_dir, comfy_queue, exit_event)
+        await start_tasks_engine(flows_dir, tasks_files_dir, comfy_queue, exit_event)
         if ui_dir:
             _app.mount("/", StaticFiles(directory=ui_dir, html=True), name="client")
         yield

--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -93,6 +93,10 @@ def get_installed_flows(flows_dir: str, flows_comfy: list | None = None) -> list
     return r
 
 
+def get_installed_flows_names(flows_dir: str) -> list[str]:
+    return [i["name"] for i in get_installed_flows(flows_dir)]
+
+
 def get_installed_flow(flows_dir: str, flow_name: str, flow_comfy: dict[str, dict]) -> dict[str, typing.Any]:
     flows_comfy = []
     for i, flow in enumerate(get_installed_flows(flows_dir, flows_comfy)):


### PR DESCRIPTION
Each Vix instance can have different tasks installed, so you only need to request execution of those tasks that a specific instance can process