### PR TITLE
(feat): Task times: locked_at, created_at, updated_at, finished_at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0 - 2024-05-0x]
 
+Breaking change: new database needs to be created(new fields was added), just delete the old one.
+
 ### Added
 
 - Option `Fast(AlignYourSteps)` for `Aesthetic(Playground)` and `Juggernaut` workflows.
+- `locked_at`, `created_at`, `updated_at`, `finished_at` - new fields in the task details.
 
 ### Changed
 
 - **SUPIR Upscaler workflow rework**: tiles support(to process large images), optional "soft" mode without sharpening.
+- `/task-restart` endpoint: added `force` optional parameter, which allows to restart the task which has no "error" state set.
 
 ### Fixed
 

--- a/visionatrix/database.py
+++ b/visionatrix/database.py
@@ -1,6 +1,6 @@
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 from passlib.context import CryptContext
 from sqlalchemy import (
@@ -38,7 +38,7 @@ class TaskDetails(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     task_id = Column(Integer, ForeignKey("tasks_queue.id"), nullable=False, unique=True)
     user_id = Column(String, ForeignKey("users.user_id"), nullable=False, index=True)
-    progress = Column(Float, default=0.0)
+    progress = Column(Float, default=0.0, index=True)
     error = Column(String, default="")
     name = Column(String, default="")
     input_params = Column(JSON, default={})
@@ -47,6 +47,9 @@ class TaskDetails(Base):
     flow_comfy = Column(JSON, default={})
     task_queue = relationship("TaskQueue")
     user_info = relationship("UserInfo", backref="task_details")
+    created_at = Column(DateTime, default=datetime.now(timezone.utc))
+    updated_at = Column(DateTime, nullable=True, default=None)
+    finished_at = Column(DateTime, nullable=True, default=None)
     execution_time = Column(Float, default=0.0)
 
 
@@ -54,7 +57,7 @@ class TaskLock(Base):
     __tablename__ = "task_locks"
     id = Column(Integer, primary_key=True, autoincrement=True)
     task_id = Column(Integer, ForeignKey("tasks_queue.id"), nullable=False, unique=True)
-    locked_at = Column(DateTime, default=datetime.utcnow)
+    locked_at = Column(DateTime, default=datetime.now(timezone.utc))
     task_queue = relationship("TaskQueue", backref="lock")
 
 

--- a/visionatrix/pydantic_models.py
+++ b/visionatrix/pydantic_models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 
@@ -86,12 +88,16 @@ class TaskDetailsShort(BaseModel):
     input_files: list[str] = Field(
         ..., description="Incoming file parameters based on which the ComfyUI workflow was generated."
     )
+    locked_at: datetime | None = Field(None, description="Lock time if task is locked.")
     execution_time: float = Field(..., description="Execution time of the ComfyUI workflow in seconds.")
 
 
 class TaskDetails(TaskDetailsShort):
     """Detailed information about the Task."""
 
+    created_at: datetime = Field(..., description="Task creation time.")
+    updated_at: datetime | None = Field(None, description="Last task update time.")
+    finished_at: datetime | None = Field(None, description="Finish time of the task.")
     task_id: int = Field(..., description="Unique identifier of the task.")
     flow_comfy: dict = Field(..., description="The final generated ComfyUI workflow.")
     user_id: str = Field(..., description="User ID to whom the task belongs.")


### PR DESCRIPTION
This allows us to add to the UI a display of whether a task is locked or just frozen, as well as possible filtering of tasks by days of creation and completion.

It is also now possible to reset tasks, without the `error` being set at the `task-restart` endpoint.