### PR TITLE
reset local repo state for CustomNode when "git pull" fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Removed relation between `users` table and others, which now correctly allows to implement connection of third party user backends.
+- In some cases, when commits were reverted in the node's remote repositories, the `update` command completed with an error. #86
 
 ## [0.3.0 - 2024-06-09]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Removed relation between `users` table and others, which now correctly allows to implement connection of third party user backends.
-- In some cases, when commits were reverted in the node's remote repositories, the `update` command completed with an error. #86
+- In some cases, when commits were reverted in the node's remote repositories, the `update` command completed with an error. #87
 
 ## [0.3.0 - 2024-06-09]
 


### PR DESCRIPTION
Tried update today my setup, after yesterday starting updating Nodes for the upcoming `0.4.0` version and got:

```
From https://github.com/Visionatrix/ComfyUI_essentials
 + 94b7450...b0cfa1b main       -> origin/main  (forced update)
hint: You have divergent branches and need to specify how to reconcile them.
hint: You can do so by running one of the following commands sometime before
hint: your next pull:
hint: 
hint:   git config pull.rebase false  # merge
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint: 
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
fatal: Need to specify how to reconcile divergent branches.
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/shurik/PycharmProjects/Visionatrix/visionatrix/__main__.py", line 128, in <module>
    update()
  File "/Users/shurik/PycharmProjects/Visionatrix/visionatrix/install_update/update.py", line 55, in update
    update_base_custom_nodes()
  File "/Users/shurik/PycharmProjects/Visionatrix/visionatrix/install_update/custom_nodes.py", line 106, in update_base_custom_nodes
    run("git pull".split(), check=True, cwd=os.path.join(custom_nodes_dir, node_name))
  File "/Users/shurik/miniconda3/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'pull']' returned non-zero exit status 128.
```

Reference: https://github.com/cubiq/ComfyUI_essentials/issues/49