### PR TITLE
stop dividing by zero if flow has no models

### DIFF
--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -145,7 +145,7 @@ def install_custom_flow(
     progress_info = {
         "name": flow.name,
         "current": 1.0,
-        "progress_for_model": 97 / len(flow.models),
+        "progress_for_model": 97 / max(len(flow.models), 1),
     }
     if progress_callback is not None:
         progress_callback(flow.name, progress_info["current"], "")


### PR DESCRIPTION
I found this when I was making a flow to [remove the background](https://github.com/Visionatrix/VixFlowsDocs/pull/18), there the model is included in the node itself, that is, in fact, a flow without models for installation for our case.
