### PR TITLE
Flow model: `is_seed_supported` and `is_count_supported` flags

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1932,6 +1932,18 @@
             "title": "New Version Available",
             "description": "If not empty, contains the new version of the workflow.",
             "default": ""
+          },
+          "is_seed_supported": {
+            "type": "boolean",
+            "title": "Is Seed Supported",
+            "description": "Flag determining if 'Random Seed' input will be displayed in the UI.",
+            "default": true
+          },
+          "is_count_supported": {
+            "type": "boolean",
+            "title": "Is Count Supported",
+            "description": "Flag determining if 'Number of images' input will be displayed in the UI.",
+            "default": true
           }
         },
         "type": "object",
@@ -2693,7 +2705,7 @@
             "format": "date-time",
             "title": "Last Seen",
             "description": "Last seen time",
-            "default": "2024-08-08T14:17:04.861129Z"
+            "default": "2024-08-10T09:49:15.565064Z"
           }
         },
         "type": "object",

--- a/visionatrix/pydantic_models.py
+++ b/visionatrix/pydantic_models.py
@@ -66,6 +66,12 @@ class Flow(BaseModel):
     requires: list[str] = Field(default=[], description="Required external workflow dependencies.")
     private: bool = Field(False, description="Whether the workflow is missing from the `FLOWS_CATALOG_URL`")
     new_version_available: str = Field("", description="If not empty, contains the new version of the workflow.")
+    is_seed_supported: bool = Field(
+        True, description="Flag determining if 'Random Seed' input will be displayed in the UI."
+    )
+    is_count_supported: bool = Field(
+        True, description="Flag determining if 'Number of images' input will be displayed in the UI."
+    )
 
 
 class FlowProgressInstall(BaseModel):


### PR DESCRIPTION
<img width="1255" alt="image" src="https://github.com/user-attachments/assets/cf83f677-f707-441d-b1aa-c0b6c186e17b">

"Remove background" flow is not supporting both UI inputs, lets add ability from backend to indicate to UI to not display them