### PR TITLE
catch httpx.NetworkError exception during flows info fetch

### DIFF
--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -24,7 +24,7 @@ from .nodes_helpers import get_node_value, set_node_value
 from .pydantic_models import Flow
 
 SECONDS_TO_CACHE_INSTALLED_FLOWS = 10
-SECONDS_TO_CACHE_AVALAIBLE_FLOWS = 60
+SECONDS_TO_CACHE_AVALAIBLE_FLOWS = 3 * 60
 
 LOGGER = logging.getLogger("visionatrix")
 CACHE_AVAILABLE_FLOWS = {
@@ -54,7 +54,12 @@ def get_available_flows(flows_comfy: list) -> list[Flow]:
         else:
             flows_storage_url += f"flows-{vix_version.major}.{vix_version.minor}.zip"
     if urlparse(flows_storage_url).scheme in ("http", "https", "ftp", "ftps"):
-        r = httpx.get(flows_storage_url, headers={"If-None-Match": CACHE_AVAILABLE_FLOWS["etag"]}, timeout=5.0)
+        try:
+            r = httpx.get(flows_storage_url, headers={"If-None-Match": CACHE_AVAILABLE_FLOWS["etag"]}, timeout=5.0)
+        except httpx.NetworkError as e:
+            LOGGER.error("Request to get flows failed with: %s", str(e))
+            flows_comfy.extend(CACHE_AVAILABLE_FLOWS["flows_comfy"])
+            return CACHE_AVAILABLE_FLOWS["flows"]
         if r.status_code == 304:
             flows_comfy.extend(CACHE_AVAILABLE_FLOWS["flows_comfy"])
             return CACHE_AVAILABLE_FLOWS["flows"]


### PR DESCRIPTION
when the internet is accidentally lost and at that moment the backend decides to fetch with the replication of new flows - an unhandled exception occurs.

for this case we will simply return the last list of available flows that we had - this is definitely better than the 500 error that is returned like this.

Also increased cache time for flows from 60 sec to 180 sec,- we definitely doesn't updating flows in repo each minute =)