### PR TITLE
processing of KSamplerAdvanced.noise_seed value

### DIFF
--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -322,7 +322,7 @@ def process_seed_value(flow: Flow, in_texts_params: dict, flow_comfy: dict[str, 
             if "seed" in node_details["inputs"]:
                 node_details["inputs"]["seed"] = random_seed
             elif (
-                node_details["class_type"] in ("SamplerCustom", "RandomNoise")
+                node_details["class_type"] in ("SamplerCustom", "RandomNoise", "KSamplerAdvanced")
                 and "noise_seed" in node_details["inputs"]
             ):
                 node_details["inputs"]["noise_seed"] = random_seed


### PR DESCRIPTION
It's strange, but we didn't have this, although it seems like we have Workflows with this node - apparently they just overlooked it.

Fixed

*Found when implementing new ColorfulXL workflow for Vix 1.0*