### PR TITLE
added ability to run `easy-install` script from the PR branches

### DIFF
--- a/scripts/easy_install.py
+++ b/scripts/easy_install.py
@@ -148,8 +148,13 @@ def update_visionatrix():
         major_version = get_major_version(visionatrix_version)
         latest_version_tag = get_latest_version(major_version)
         if latest_version_tag != f"v{visionatrix_version}":
-            print(f"Updating to the latest version {latest_version_tag} in this major version {major_version}..")
-            subprocess.check_call(["git", "checkout", f"tags/{latest_version_tag}"], env=clone_env)
+            if latest_version_tag is None:
+                result = subprocess.run(["git", "pull"], capture_output=True, text=True)
+                if "Already up to date." in result.stdout:
+                    print("No new commits were pulled.")
+            else:
+                print(f"Updating to the latest version {latest_version_tag} in this major version {major_version}..")
+                subprocess.check_call(["git", "checkout", f"tags/{latest_version_tag}"], env=clone_env)
         else:
             latest_version_tag = get_latest_version(major_version + 1)
             if latest_version_tag is None:


### PR DESCRIPTION
The ability to update all nodes will be convenient when we have a large PR that we work on for 2+ weeks, like now with ChildTasks.

This will allow me to simultaneously freeze the nodes today and start preparing for the release without switching from the PR to run the script.