### PR TITLE
made models for Nodes appear in the flow models list

### DIFF
--- a/.run/module-install-flow.run.xml
+++ b/.run/module-install-flow.run.xml
@@ -15,7 +15,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="visionatrix" />
-    <option name="PARAMETERS" value="install-flow --directory flows/sdxl_lighting_8" />
+    <option name="PARAMETERS" value="install-flow --name=vintage_portrait" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - New `--reserve-vram` and `--fast` commandline options from the last ComfyUI.
 
+### Fixed
+
+- Now for nodes like `ComfyUI_InstantID` or `ComfyUI-BRIA_AI-RMBG`, their required models are displayed in the flow models.
+
 ### Changed
 
 - ComfyUI updated with PR #2666 (Execution Model Inversion)

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "visionatrix",
-    "version": "1.0.1"
+    "version": "1.1.0.dev0"
   },
   "paths": {
     "/api/flows/installed": {
@@ -1658,6 +1658,12 @@
             "title": "Hash",
             "description": "SHA256 hash of the model file for integrity verification."
           },
+          "hashes": {
+            "type": "object",
+            "title": "Hashes",
+            "description": "For archives, may contain filename:hash pairs for integrity checks after the archive is deleted.",
+            "default": {}
+          },
           "regexes": {
             "items": {
               "type": "object"
@@ -2891,7 +2897,7 @@
             "format": "date-time",
             "title": "Last Seen",
             "description": "Last seen time",
-            "default": "2024-08-20T17:36:00.696493Z"
+            "default": "2024-08-25T14:00:59.083560Z"
           }
         },
         "type": "object",

--- a/scripts/ci/release_tag_repos.py
+++ b/scripts/ci/release_tag_repos.py
@@ -7,7 +7,7 @@ from time import sleep
 
 from packaging.version import Version
 
-from visionatrix import _version, install_update  # noqa
+from visionatrix import _version, basic_node_list  # noqa
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 if os.environ.get("CI", False) and not GITHUB_TOKEN:
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         rmtree("temp_repo_clones", onerror=remove_readonly)
     os.mkdir("temp_repo_clones")
 
-    for r in [*install_update.BASIC_NODE_LIST, "ComfyUI"]:
+    for r in [*basic_node_list.BASIC_NODE_LIST, "ComfyUI"]:
         tag_repository(r, f"v{visionatrix_version.base_version}")
 
     if visionatrix_version.is_prerelease:

--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -138,6 +138,7 @@ if __name__ == "__main__":
     elif args.command == "run":
         run_vix()
     elif args.command == "install-flow":
+        comfyui.load(None)
         install_flow = {}
         if args.file:
             with builtins.open(Path(args.file), "rb") as fp:
@@ -147,12 +148,12 @@ if __name__ == "__main__":
             flows_comfy = []
             flows = get_available_flows(flows_comfy)
             for i, flow in enumerate(flows):
-                if flow.name == args.flow:
+                if flow.name == args.name:
                     install_flow = flow
                     install_flow_comfy = flows_comfy[i]
                     break
             if not install_flow:
-                logging.getLogger("visionatrix").error("Can not find the specific flow: %s", args.flow)
+                logging.getLogger("visionatrix").error("Can not find the specific flow: %s", args.name)
                 sys.exit(2)
         install_custom_flow(flow=install_flow, flow_comfy=install_flow_comfy, progress_callback=__progress_callback)
     else:

--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -1,0 +1,78 @@
+from .pydantic_models import AIResourceModel
+
+BASIC_NODE_LIST = {
+    "ComfyUI-Impact-Pack": {
+        "main_branch": "Main",
+    },
+    "ComfyUI_UltimateSDUpscale": {
+        "git_flags": "--recursive",
+    },
+    "ComfyUI_InstantID": {
+        "requirements": {
+            "insightface": {},
+            "onnxruntime": {},
+        },
+        "models": [
+            AIResourceModel(
+                name="antelopev2",
+                save_path="{root}models/insightface/models/antelopev2.zip",
+                url="https://huggingface.co/MonsterMMORPG/tools/resolve/main/antelopev2.zip",
+                homepage="https://github.com/deepinsight/insightface",
+                hash="8e182f14fc6e80b3bfa375b33eb6cff7ee05d8ef7633e738d1c89021dcf0c5c5",
+                hashes={
+                    "1k3d68.onnx": "df5c06b8a0c12e422b2ed8947b8869faa4105387f199c477af038aa01f9a45cc",
+                    "2d106det.onnx": "f001b856447c413801ef5c42091ed0cd516fcd21f2d6b79635b1e733a7109dbf",
+                    "genderage.onnx": "4fde69b1c810857b88c64a335084f1c3fe8f01246c9a191b48c7bb756d6652fb",
+                    "glintr100.onnx": "4ab1d6435d639628a6f3e5008dd4f929edf4c4124b1a7169e1048f9fef534cdf",
+                    "scrfd_10g_bnkps.onnx": "5838f7fe053675b1c7a08b633df49e7af5495cee0493c7dcf6697200b85b5b91",
+                },
+            ),
+        ],
+    },
+    "ComfyUI-BRIA_AI-RMBG": {
+        "models": [
+            AIResourceModel(
+                name="RMGB-1.4",
+                save_path="{root}custom_nodes/ComfyUI-BRIA_AI-RMBG/RMBG-1.4/model.pth",
+                url="https://huggingface.co/andrey18106/vix_models/resolve/main/RMBG-1.4/model.pth",
+                homepage="https://huggingface.co/briaai/RMBG-1.4",
+                hash="893c16c340b1ddafc93e78457a4d94190da9b7179149f8574284c83caebf5e8c",
+            ),
+        ],
+    },
+    "efficiency-nodes-comfyui": {
+        "requirements": {
+            "simpleeval": {},
+        }
+    },
+    "ComfyUI-WD14-Tagger": {},
+    "ComfyUI-SUPIR": {},
+    "ComfyUI_essentials": {},
+    "rgthree-comfy": {},
+    "ComfyUI-Custom-Scripts": {},
+    "ComfyUI_IPAdapter_plus": {},
+    "comfyui_controlnet_aux": {},
+    "Skimmed_CFG": {},
+    "comfyui-art-venture": {},
+    "was-node-suite-comfyui": {},
+    "ComfyUI-Visionatrix": {},
+    "comfyui-ollama": {},
+    "ComfyUI-AutoCropFaces": {},
+    "PuLID_ComfyUI": {
+        "before_install": {
+            "python": "-m pip install --use-pep517 facexlib",
+        },
+        "requirements": {
+            "facexlib": {},
+            "insightface": {},
+            "onnxruntime": {},
+            "ftfy": {},
+            "timm": {},
+        },
+    },
+    "ComfyUI_FizzNodes": {},
+    "style_aligned_comfy": {
+        "main_branch": "master",
+    },
+    "ComfyUI_Gemini_Flash": {},
+}

--- a/visionatrix/comfyui.py
+++ b/visionatrix/comfyui.py
@@ -45,6 +45,10 @@ def load(task_progress_callback) -> [typing.Callable[[dict], tuple[bool, dict, l
         "--ui",
         "--loglevel",
         "^run$",
+        "^update$",
+        "^install-flow$",
+        "--name=",
+        "--file=",
         "--mode",
         "--server",
         "--disable-device-detection",
@@ -100,6 +104,9 @@ def load(task_progress_callback) -> [typing.Callable[[dict], tuple[bool, dict, l
     folder_paths.add_model_folder_path("checkpoints", os.path.join(folder_paths.get_output_directory(), "checkpoints"))
     folder_paths.add_model_folder_path("clip", os.path.join(folder_paths.get_output_directory(), "clip"))
     folder_paths.add_model_folder_path("vae", os.path.join(folder_paths.get_output_directory(), "vae"))
+    folder_paths.add_model_folder_path(
+        "diffusion_models", os.path.join(folder_paths.get_output_directory(), "diffusion_models")
+    )
     folder_paths.set_input_directory(str(Path(options.TASKS_FILES_DIR).joinpath("input")))
 
     return execution.validate_prompt, get_comfy_prompt_executor(comfy_server, task_progress_callback)
@@ -131,6 +138,12 @@ def get_comfy_prompt_executor(comfy_server, task_progress_callback):
             task_progress_callback(event, data, broadcast)
 
     return ComfyPromptExecutor(comfy_server)
+
+
+def get_node_class_mappings() -> dict[str, object]:
+    import nodes  # noqa
+
+    return nodes.NODE_CLASS_MAPPINGS
 
 
 def interrupt_processing() -> None:

--- a/visionatrix/install_update/__init__.py
+++ b/visionatrix/install_update/__init__.py
@@ -1,3 +1,2 @@
-from .custom_nodes import BASIC_NODE_LIST
 from .install import install
 from .update import update

--- a/visionatrix/install_update/custom_nodes.py
+++ b/visionatrix/install_update/custom_nodes.py
@@ -9,78 +9,9 @@ import httpx
 from packaging.version import Version
 
 from .. import _version, options
-from ..models import install_model
-from ..pydantic_models import AIResourceModel
+from ..basic_node_list import BASIC_NODE_LIST
 
 LOGGER = logging.getLogger("visionatrix")
-BASIC_NODE_LIST = {
-    "ComfyUI-Impact-Pack": {
-        "main_branch": "Main",
-    },
-    "ComfyUI_UltimateSDUpscale": {
-        "git_flags": "--recursive",
-    },
-    "ComfyUI_InstantID": {
-        "requirements": {
-            "insightface": {},
-            "onnxruntime": {},
-        },
-        "models": [
-            AIResourceModel(
-                name="antelopev2",
-                save_path="{root}models/insightface/models/antelopev2.zip",
-                url="https://huggingface.co/MonsterMMORPG/tools/resolve/main/antelopev2.zip",
-                hash="8e182f14fc6e80b3bfa375b33eb6cff7ee05d8ef7633e738d1c89021dcf0c5c5",
-            ),
-        ],
-    },
-    "ComfyUI-BRIA_AI-RMBG": {
-        "models": [
-            AIResourceModel(
-                name="RMGB-1.4",
-                save_path="{root}custom_nodes/ComfyUI-BRIA_AI-RMBG/RMBG-1.4/model.pth",
-                url="https://huggingface.co/andrey18106/vix_models/resolve/main/RMBG-1.4/model.pth",
-                homepage="https://huggingface.co/briaai/RMBG-1.4",
-                hash="893c16c340b1ddafc93e78457a4d94190da9b7179149f8574284c83caebf5e8c",
-            ),
-        ],
-    },
-    "efficiency-nodes-comfyui": {
-        "requirements": {
-            "simpleeval": {},
-        }
-    },
-    "ComfyUI-WD14-Tagger": {},
-    "ComfyUI-SUPIR": {},
-    "ComfyUI_essentials": {},
-    "rgthree-comfy": {},
-    "ComfyUI-Custom-Scripts": {},
-    "ComfyUI_IPAdapter_plus": {},
-    "comfyui_controlnet_aux": {},
-    "Skimmed_CFG": {},
-    "comfyui-art-venture": {},
-    "was-node-suite-comfyui": {},
-    "ComfyUI-Visionatrix": {},
-    "comfyui-ollama": {},
-    "ComfyUI-AutoCropFaces": {},
-    "PuLID_ComfyUI": {
-        "before_install": {
-            "python": "-m pip install --use-pep517 facexlib",
-        },
-        "requirements": {
-            "facexlib": {},
-            "insightface": {},
-            "onnxruntime": {},
-            "ftfy": {},
-            "timm": {},
-        },
-    },
-    "ComfyUI_FizzNodes": {},
-    "style_aligned_comfy": {
-        "main_branch": "master",
-    },
-    "ComfyUI_Gemini_Flash": {},
-}
 
 
 def install_base_custom_nodes() -> None:
@@ -110,9 +41,6 @@ def install_base_custom_node(node_name: str, node_details: dict) -> None:
     _before_install(node_name, node_details)
     _install_requirements(custom_nodes_dir, node_name, node_details)
     _run_install_script(custom_nodes_dir, node_name)
-    if "models" in node_details:
-        for i in node_details["models"]:
-            install_model(i, {}, None)
 
 
 def update_base_custom_nodes() -> None:

--- a/visionatrix/install_update/update.py
+++ b/visionatrix/install_update/update.py
@@ -6,7 +6,7 @@ from subprocess import CalledProcessError, check_call
 
 from packaging.version import Version
 
-from .. import _version, options
+from .. import _version, comfyui, options
 from ..flows import get_available_flows, get_installed_flows, install_custom_flow
 from .custom_nodes import update_base_custom_nodes
 from .install import create_missing_models_dirs
@@ -20,16 +20,6 @@ def __progress_callback(name: str, progress: float, error: str) -> None:
 
 
 def update() -> None:
-    logging.info("Updating flows..")
-    avail_flows_comfy = []
-    avail_flows = get_available_flows(avail_flows_comfy)
-    avail_flows_names = [v.name for v in avail_flows]
-    for i in get_installed_flows():
-        if i.name in avail_flows_names:
-            v = avail_flows_names.index(i.name)
-            install_custom_flow(avail_flows[v], avail_flows_comfy[v], __progress_callback)
-        else:
-            logging.warning("`%s` flow not found in repository, skipping update of it.", i.name)
     if options.BACKEND_DIR:
         if options.PYTHON_EMBEDED:
             create_missing_models_dirs()
@@ -58,3 +48,14 @@ def update() -> None:
         create_missing_models_dirs()
         logging.info("Updating custom nodes..")
         update_base_custom_nodes()
+    comfyui.load(None)
+    logging.info("Updating flows..")
+    avail_flows_comfy = []
+    avail_flows = get_available_flows(avail_flows_comfy)
+    avail_flows_names = [v.name for v in avail_flows]
+    for i in get_installed_flows():
+        if i.name in avail_flows_names:
+            v = avail_flows_names.index(i.name)
+            install_custom_flow(avail_flows[v], avail_flows_comfy[v], __progress_callback)
+        else:
+            logging.warning("`%s` flow not found in repository, skipping update of it.", i.name)

--- a/visionatrix/pydantic_models.py
+++ b/visionatrix/pydantic_models.py
@@ -36,6 +36,10 @@ class AIResourceModel(BaseModel):
     url: str = Field(..., description="URL from which the model can be downloaded.")
     homepage: str = Field("", description="Webpage with detailed information about the model.")
     hash: str = Field(..., description="SHA256 hash of the model file for integrity verification.")
+    hashes: dict = Field(
+        {},
+        description="For archives, may contain filename:hash pairs for integrity checks after the archive is deleted.",
+    )
     regexes: list[dict] = Field(
         default=[],
         description="List of regex patterns that dynamically resolve model details based on workflow configurations.",


### PR DESCRIPTION
This PR solves a long-standing flaw when we can specify which models to download when installing a node, but these models are not displayed on the flow installation screen.

Since we do have a direct relationship between the flow of ComfyUI, since it consists of class names, and not the repository name, and our models are tied to the repository name in the case of nodes.

```python3
BASIC_NODE_LIST = {
    "ComfyUI-BRIA_AI-RMBG": {
        "models": [
            AIResourceModel(
                name="RMGB-1.4",
                save_path="{root}custom_nodes/ComfyUI-BRIA_AI-RMBG/RMBG-1.4/model.pth",
                url="https://huggingface.co/andrey18106/vix_models/resolve/main/RMBG-1.4/model.pth",
                homepage="https://huggingface.co/briaai/RMBG-1.4",
                hash="893c16c340b1ddafc93e78457a4d94190da9b7179149f8574284c83caebf5e8c",
            ),
        ],
    },
}    
```    

Therefore, this PR takes a list of nodes loaded into ComfyUI, searches for matches, and gets a list of `AIResourceModel` at the output and adds it to the flow models.

1. This will allow a much more accurate representation of which models are used (for example, ComfyUI-BRIA_AI-RMBG has a Not-Commercial license)
2. Also, now these models will only be downloaded when installing flow (previously they were downloaded after installing the node) - this will reduce the size of the Zip archive for Windows **by ~500 megabytes** (140 MB BRIA_AI-RMBG + 360 megabytes antelopev2.zip for InSightFace)
3. This will allow us to add new background removal node, that needs model and we will not increase the overall size of the windows archive =)