### PR TITLE
feat: new `MAX_PARALLEL_DOWNLOADS` option

### DIFF
--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from . import comfyui, database, install, options, run_vix, update
 from .flows import get_available_flows, get_vix_flow, install_custom_flow
+from .install_update import flow_install_callback
 from .orphan_models import process_orphan_models
 
 
@@ -33,13 +34,6 @@ def get_higher_log_level(current_level):
         logging.CRITICAL: logging.CRITICAL,
     }
     return level_mapping.get(current_level, logging.WARNING)
-
-
-def __progress_callback(name: str, progress: float, error: str) -> None:
-    if not error:
-        logging.info("`%s` installation: %s", name, progress)
-    else:
-        logging.error("`%s` installation failed: %s", name, error)
 
 
 if __name__ == "__main__":
@@ -170,7 +164,9 @@ if __name__ == "__main__":
             if not install_flow:
                 logging.getLogger("visionatrix").error("Can not find the specific flow: %s", args.name)
                 sys.exit(2)
-        install_custom_flow(flow=install_flow, flow_comfy=install_flow_comfy, progress_callback=__progress_callback)
+        install_custom_flow(
+            flow=install_flow, flow_comfy=install_flow_comfy, progress_callback=flow_install_callback.progress_callback
+        )
     elif args.command == "orphan-models":
         comfyui.load(None)
         process_orphan_models(args.dry_run, args.no_confirm, args.include_useful_models)

--- a/visionatrix/install_update/flow_install_callback.py
+++ b/visionatrix/install_update/flow_install_callback.py
@@ -1,0 +1,23 @@
+import logging
+import math
+import sys
+
+FLOW_INSTALLATION_PROGRESS = 0
+
+
+def progress_callback(name: str, progress: float, error: str, relative_progress: bool) -> bool:
+    """Callback for `install-flow` and `update` CLI commands."""
+    global FLOW_INSTALLATION_PROGRESS
+
+    if error:
+        logging.error("`%s` installation failed: %s", name, error)
+        sys.exit(4)  # don't return "False" like in `__progress_install_callback`, but simply terminate the process.
+    if relative_progress:
+        FLOW_INSTALLATION_PROGRESS += progress
+    else:
+        FLOW_INSTALLATION_PROGRESS = progress
+    if FLOW_INSTALLATION_PROGRESS >= 100:
+        logging.info("`%s` installation finished!", name)
+    else:
+        logging.info("`%s` installation: %s", name, math.floor(FLOW_INSTALLATION_PROGRESS * 10) / 10)
+    return True

--- a/visionatrix/install_update/update.py
+++ b/visionatrix/install_update/update.py
@@ -8,15 +8,9 @@ from packaging.version import Version
 
 from .. import _version, comfyui, options
 from ..flows import get_available_flows, get_installed_flows, install_custom_flow
+from . import flow_install_callback
 from .custom_nodes import update_base_custom_nodes
 from .install import create_missing_models_dirs
-
-
-def __progress_callback(name: str, progress: float, error: str) -> None:
-    if not error:
-        logging.info("`%s` installation: %s", name, progress)
-    else:
-        logging.error("`%s` installation failed: %s", name, error)
 
 
 def update() -> None:
@@ -56,6 +50,7 @@ def update() -> None:
     for i in get_installed_flows():
         if i.name in avail_flows_names:
             v = avail_flows_names.index(i.name)
-            install_custom_flow(avail_flows[v], avail_flows_comfy[v], __progress_callback)
+            flow_install_callback.progress_callback(avail_flows[v].name, 0.0, "", False)
+            install_custom_flow(avail_flows[v], avail_flows_comfy[v], flow_install_callback.progress_callback)
         else:
             logging.warning("`%s` flow not found in repository, skipping update of it.", i.name)

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -81,6 +81,11 @@ Example:
 This will enable `nextcloud` user backend in addition to the default `vix_db`.
 """
 
+MAX_PARALLEL_DOWNLOADS = int(environ.get("MAX_PARALLEL_DOWNLOADS", "2"))
+"""Maximum number of parallel downloads allowed during flow installation.
+Defaults to ``2`` if the environment variable is not set.
+"""
+
 
 def init_dirs_values(backend: str | None, flows: str | None, models: str | None, tasks_files: str | None) -> None:
     global BACKEND_DIR, FLOWS_DIR, MODELS_DIR, TASKS_FILES_DIR


### PR DESCRIPTION
Working on a new benchmark, I encountered a problem when installing Visionatrix on a remote server.

With a server channel of ~1Gbps, downloading some models from a HuggingFace goes at a speed of 300-400 Mbps.

This pull request should solve this problem:

* **now by default**, two models are downloaded in parallel and this value can be changed using the new environment variable `MAX_PARALLEL_DOWNLOADS`

For home use, this will not hurt either, even a small acceleration of installation will be useful.