### PR TITLE
fix: use pytorch for CPU for CI speedup

### DIFF
--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -23,9 +23,6 @@ jobs:
         run: python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 
       - name: Install from source
-        run: python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
-
-      - name: Install from source
         run: python3 -m pip install ".[dev]"
 
       - name: Save current OpenAPI specs

--- a/.github/workflows/openapi-check.yml
+++ b/.github/workflows/openapi-check.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install PyTorch for CPU
+        run: python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+
       - name: Install from source
         run: python3 -m pip install ".[dev]"
 


### PR DESCRIPTION
Without it we have `OpenAPI checks / Up to date (pull_request) Successful in 5m`

With these changes: `OpenAPI checks / Up to date (pull_request) Successful in 1m`