### PR TITLE
readme: command for Linux in to install basic packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Requirements:
 
 ### Linux/macOS/WSL:
 
+<details>
+  <summary>Installing pre-requirements(python, git,...)</summary>
+
+  For Ubuntu 22.04:
+
+  ```console
+  sudo apt install wget curl python3-venv python3-pip build-essential git
+  ```
+  <hr>
+</details>
+
 Download and execute `easy_install.py` script:
 
 > [!NOTE]


### PR DESCRIPTION
I checked it today on a clean instance here: https://akash.network/

These packages on a clean Ubuntu 22.04 are enough for Visionatrix to work perfectly.

It's better to mention it in the readme (it might be worth mentioning in the docs too, according to the installation manual)