### PR TITLE
fix(installation): do several  "git clone" attempts

### DIFF
--- a/visionatrix/install_update/custom_nodes.py
+++ b/visionatrix/install_update/custom_nodes.py
@@ -32,8 +32,15 @@ def install_base_custom_node(node_name: str, node_details: dict) -> None:
     clone_command = "git clone "
     what_clone = f"{os.path.join(custom_nodes_dir, node_name)}"
     clone_command += f"{github_url} {git_flags} {what_clone}"
-    print("Executing: ", clone_command)
-    run(clone_command.split(), check=True)
+    LOGGER.info("Executing: %s", clone_command)
+    for i in range(options.MAX_GIT_CLONE_ATTEMPTS):
+        try:
+            run(clone_command.split(), check=True)
+            break
+        except CalledProcessError as e:
+            LOGGER.warning("Cloning failed(attempts left(%s)", options.MAX_GIT_CLONE_ATTEMPTS - i - 1)
+            if i == options.MAX_GIT_CLONE_ATTEMPTS - 1:
+                raise e
     if not Version(_version.__version__).is_devrelease:
         clone_env = os.environ.copy()
         clone_env["GIT_CONFIG_PARAMETERS"] = "'advice.detachedHead=false'"

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -86,6 +86,9 @@ MAX_PARALLEL_DOWNLOADS = int(environ.get("MAX_PARALLEL_DOWNLOADS", "2"))
 Defaults to ``2`` if the environment variable is not set.
 """
 
+MAX_GIT_CLONE_ATTEMPTS = int(environ.get("MAX_GIT_CLONE_ATTEMPTS", "3"))
+"""Maximum number of attempts to perform `git clone` during the first installation."""
+
 
 def init_dirs_values(backend: str | None, flows: str | None, models: str | None, tasks_files: str | None) -> None:
     global BACKEND_DIR, FLOWS_DIR, MODELS_DIR, TASKS_FILES_DIR


### PR DESCRIPTION
Encountered this today when I tried to run remote benchmarks.

I rented a fancy instance with a top-end video card, but for some reason the connection to GitHub was just terrible, and the one-click installation of Visionatrix definitely didn't want to work.

This should improve the situation a little.