### PR TITLE
fixed: ignore ComfyUI `execution_cached` event if no cached nodes

### DIFF
--- a/visionatrix/tasks_engine.py
+++ b/visionatrix/tasks_engine.py
@@ -910,7 +910,7 @@ def task_progress_callback(event: str, data: dict, broadcast: bool = False):
             data["exception_message"],
             data["traceback"],
         )
-    elif event == "execution_cached":
+    elif event == "execution_cached" and len(data["nodes"]) > 1:
         increase_current_task_progress((len(data["nodes"]) - 1) * node_percent)
     elif event == "execution_interrupted":
         ACTIVE_TASK["interrupted"] = True


### PR DESCRIPTION
Oops, we've never seen this in UI, it didn't affect the work, but when the **benchmarker** works and displays negative task progress, it looks scary.
