### PR TITLE
stopped ImpactPact node from auto-downloading models

### DIFF
--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -3,6 +3,15 @@ from .pydantic_models import AIResourceModel
 BASIC_NODE_LIST = {
     "ComfyUI-Impact-Pack": {
         "main_branch": "Main",
+        "models": [
+            AIResourceModel(
+                name="sam_vit_b_01ec64",
+                save_path="{root}models/sams/sam_vit_b_01ec64.pth",
+                url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/sams/sam_vit_b_01ec64.pth",
+                homepage="https://github.com/facebookresearch/segment-anything",
+                hash="ec2df62732614e57411cdcf32a23ffdf28910380d03139ee0f4fcbe91eb8c912",
+            ),
+        ],
     },
     "ComfyUI_UltimateSDUpscale": {
         "git_flags": "--recursive",
@@ -30,7 +39,7 @@ BASIC_NODE_LIST = {
             AIResourceModel(
                 name="RMGB-1.4",
                 save_path="{root}custom_nodes/ComfyUI-BRIA_AI-RMBG/RMBG-1.4/model.pth",
-                url="https://huggingface.co/andrey18106/vix_models/resolve/main/RMBG-1.4/model.pth",
+                url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/RMBG-1.4/model.pth",
                 homepage="https://huggingface.co/briaai/RMBG-1.4",
                 hash="893c16c340b1ddafc93e78457a4d94190da9b7179149f8574284c83caebf5e8c",
             ),

--- a/visionatrix/install_update/install.py
+++ b/visionatrix/install_update/install.py
@@ -76,6 +76,7 @@ def install(operations_mask: list[bool]) -> None:
         create_missing_models_dirs()
         with builtins.open(os.path.join(options.BACKEND_DIR, "extra_model_paths.yaml"), "w", encoding="utf-8") as fp:
             fp.write(EXTRA_MODEL_PATHS.replace("vix_models_root", options.MODELS_DIR))
+        create_nodes_stuff()
         install_base_custom_nodes()
 
 
@@ -83,3 +84,11 @@ def create_missing_models_dirs() -> None:
     for k in yaml.safe_load(EXTRA_MODEL_PATHS)["vix_models"]:
         if (v := Path(options.BACKEND_DIR).joinpath("models", k)).exists() is False:
             os.makedirs(v, exist_ok=True)
+
+
+def create_nodes_stuff() -> None:
+    """Currently we only create `skip_download_model` file in "custom_nodes" for ComfyUI-Impact-Pack"""
+
+    Path(options.BACKEND_DIR).joinpath("custom_nodes").joinpath("skip_download_model").open(
+        "a", encoding="utf-8"
+    ).close()

--- a/visionatrix/install_update/update.py
+++ b/visionatrix/install_update/update.py
@@ -10,7 +10,7 @@ from .. import _version, comfyui, options
 from ..flows import get_available_flows, get_installed_flows, install_custom_flow
 from . import flow_install_callback
 from .custom_nodes import update_base_custom_nodes
-from .install import create_missing_models_dirs
+from .install import create_missing_models_dirs, create_nodes_stuff
 
 
 def update() -> None:
@@ -40,6 +40,7 @@ def update() -> None:
             )
         os.makedirs(os.path.join(options.BACKEND_DIR, "user"), exist_ok=True)  # for multiprocessing installations
         create_missing_models_dirs()
+        create_nodes_stuff()
         logging.info("Updating custom nodes..")
         update_base_custom_nodes()
     comfyui.load(None)


### PR DESCRIPTION
Size of `sam_vit_b_01ec64.pth` is 375 MB.

It is better to download it only for those flows where it is needed(Human Face Detailer), we already have such an opportunity.

It is nice, especially for standalone releases or for fast deploying to production, and in general we need to get rid of automatic downloads of something unnecessary.

From [ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack) README:

<img width="737" alt="image" src="https://github.com/user-attachments/assets/c2a3cbd0-c670-4a55-9e1a-f1b44f71f608">
