### PR TITLE
fix: worker should ask for user setting before global

### DIFF
--- a/visionatrix/install_update/install.py
+++ b/visionatrix/install_update/install.py
@@ -89,6 +89,5 @@ def create_missing_models_dirs() -> None:
 def create_nodes_stuff() -> None:
     """Currently we only create `skip_download_model` file in "custom_nodes" for ComfyUI-Impact-Pack"""
 
-    Path(options.BACKEND_DIR).joinpath("custom_nodes").joinpath("skip_download_model").open(
-        "a", encoding="utf-8"
-    ).close()
+    with Path(options.BACKEND_DIR).joinpath("custom_nodes").joinpath("skip_download_model").open("a", encoding="utf-8"):
+        pass


### PR DESCRIPTION
we always have user settings have priority over global ones.

even though we don't have some settings for the user(user for now can't define `ollama` setting from UI), the algorithm should still be correct