### PR TITLE
using `--verbose` arg for the logging lvl(the same as in last ComfyUI)

### DIFF
--- a/.run/module-run (server).run.xml
+++ b/.run/module-run (server).run.xml
@@ -15,7 +15,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="visionatrix" />
-    <option name="PARAMETERS" value="--loglevel=WARNING run --ui --mode=SERVER" />
+    <option name="PARAMETERS" value="--verbose=WARNING run --ui --mode=SERVER" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />

--- a/.run/module-run (worker, IP).run.xml
+++ b/.run/module-run (worker, IP).run.xml
@@ -15,7 +15,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="visionatrix" />
-    <option name="PARAMETERS" value="--loglevel=WARNING run --mode=WORKER --server=http://127.0.0.1:8288 --tasks_files_dir=vix_worker_tasks_files" />
+    <option name="PARAMETERS" value="--verbose=WARNING run --mode=WORKER --server=http://127.0.0.1:8288 --tasks_files_dir=vix_worker_tasks_files" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />

--- a/.run/module-run.run.xml
+++ b/.run/module-run.run.xml
@@ -16,7 +16,7 @@
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
     <option name="SCRIPT_NAME" value="visionatrix" />
-    <option name="PARAMETERS" value="--loglevel=WARNING run --ui" />
+    <option name="PARAMETERS" value="--verbose=WARNING run --ui" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />
     <option name="MODULE_MODE" value="true" />


### PR DESCRIPTION
After this commit https://github.com/comfyanonymous/ComfyUI/commit/6f021d8aa0261f7e61db6c6199d942c53a42a965 
we can change the name of the loglevel argument so that we don't have to remember that it's different from Comfy's.

Our old "--loglevel" argument is simply marked as deprecated for now, and we'll remove it in version 1.6