### PR TITLE
import pytorch later  to support PYTORCH_ENABLE_MPS_FALLBACK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ messages_control.disable = [
   "broad-exception-caught",
   "too-many-positional-arguments",
   "deprecated-argument",
+  "import-outside-toplevel",
 ]
 
 [tool.pytest.ini_options]

--- a/visionatrix/tasks_engine.py
+++ b/visionatrix/tasks_engine.py
@@ -10,7 +10,6 @@ import typing
 from datetime import datetime, timezone
 
 import httpx
-import torch
 from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
@@ -815,6 +814,8 @@ def background_prompt_executor(prompt_executor, exit_event: threading.Event):
     last_task_name = ""
     last_gc_collect = 0
     need_gc = False
+
+    import torch  # noqa
 
     while True:
         if need_gc:


### PR DESCRIPTION
Initially, we had it like that, but then during refactorings and adding various features - it broke, and those variables that we set (for example PYTORCH_ENABLE_MPS_FALLBACK=1) - were already set after importing Pytorch and it did not take them into account.

This is fixed in this PR.