### PR TITLE
(fix): Flows OpenAPI: adding seed param

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2395,11 +2395,17 @@
             "description": "Optional. Headers for webhook URL as an encoded JSON string. Used only when `webhook_url` is set.",
             "default": ""
           },
+          "seed": {
+            "type": "integer",
+            "title": "Seed",
+            "description": "The `seed` parameter for reproducing the results of workflows.",
+            "default": 1
+          },
           "count": {
             "type": "integer",
             "minimum": 1.0,
             "title": "Count",
-            "description": "Number of tasks to be created",
+            "description": "Number of tasks to be created.",
             "default": 1
           },
           "translate": {
@@ -3253,7 +3259,7 @@
             "format": "date-time",
             "title": "Last Seen",
             "description": "Last seen time",
-            "default": "2024-11-03T08:25:38.275318Z"
+            "default": "2024-11-08T08:07:36.243596Z"
           }
         },
         "type": "object",

--- a/visionatrix/custom_openapi.py
+++ b/visionatrix/custom_openapi.py
@@ -17,8 +17,12 @@ from .flows import (
 from .pydantic_models import (
     Flow,
     TaskCreationBasicParams,
+    TaskCreationWithCountAndSeedParams,
     TaskCreationWithCountParam,
     TaskCreationWithFullParams,
+    TaskCreationWithSeedParam,
+    TaskCreationWithTranslateAndCountParams,
+    TaskCreationWithTranslateAndSeedParams,
     TaskCreationWithTranslateParam,
     TaskRunResults,
 )
@@ -94,12 +98,24 @@ def create_dynamic_model(flow_definition: Flow) -> type[BaseModel]:
             )
         model_fields[param["name"]] = model_field
 
-    if flow_definition.is_count_supported and flow_definition.is_translations_supported:
+    if (
+        flow_definition.is_count_supported
+        and flow_definition.is_translations_supported
+        and flow_definition.is_seed_supported
+    ):
         base_model = TaskCreationWithFullParams
+    elif flow_definition.is_count_supported and flow_definition.is_seed_supported:
+        base_model = TaskCreationWithCountAndSeedParams
+    elif flow_definition.is_count_supported and flow_definition.is_translations_supported:
+        base_model = TaskCreationWithTranslateAndCountParams
+    elif flow_definition.is_translations_supported and flow_definition.is_seed_supported:
+        base_model = TaskCreationWithTranslateAndSeedParams
     elif flow_definition.is_translations_supported:
         base_model = TaskCreationWithTranslateParam
     elif flow_definition.is_count_supported:
         base_model = TaskCreationWithCountParam
+    elif flow_definition.is_seed_supported:
+        base_model = TaskCreationWithSeedParam
     else:
         base_model = TaskCreationBasicParams
 

--- a/visionatrix/pydantic_models.py
+++ b/visionatrix/pydantic_models.py
@@ -337,11 +337,15 @@ class TaskCreationBasicParams(BaseModel):
 
 
 class TaskCreationCountParam(BaseModel):
-    count: int = Field(1, description="Number of tasks to be created", ge=1)
+    count: int = Field(1, description="Number of tasks to be created.", ge=1)
 
 
 class TaskCreationTranslateParam(BaseModel):
     translate: int = Field(0, description="Should the prompt be translated if auto-translation option is enabled.")
+
+
+class TaskCreationSeedParam(BaseModel):
+    seed: int = Field(1, description="The `seed` parameter for reproducing the results of workflows.")
 
 
 class TaskCreationWithTranslateParam(TaskCreationTranslateParam, TaskCreationBasicParams):
@@ -352,5 +356,27 @@ class TaskCreationWithCountParam(TaskCreationCountParam, TaskCreationBasicParams
     model_config = ConfigDict(extra="ignore")
 
 
-class TaskCreationWithFullParams(TaskCreationTranslateParam, TaskCreationCountParam, TaskCreationBasicParams):
+class TaskCreationWithSeedParam(TaskCreationSeedParam, TaskCreationBasicParams):
+    model_config = ConfigDict(extra="ignore")
+
+
+class TaskCreationWithTranslateAndSeedParams(
+    TaskCreationTranslateParam, TaskCreationSeedParam, TaskCreationBasicParams
+):
+    model_config = ConfigDict(extra="ignore")
+
+
+class TaskCreationWithTranslateAndCountParams(
+    TaskCreationTranslateParam, TaskCreationCountParam, TaskCreationBasicParams
+):
+    model_config = ConfigDict(extra="ignore")
+
+
+class TaskCreationWithCountAndSeedParams(TaskCreationCountParam, TaskCreationSeedParam, TaskCreationBasicParams):
+    model_config = ConfigDict(extra="ignore")
+
+
+class TaskCreationWithFullParams(
+    TaskCreationTranslateParam, TaskCreationCountParam, TaskCreationSeedParam, TaskCreationBasicParams
+):
     model_config = ConfigDict(extra="ignore")

--- a/visionatrix/routes/tasks.py
+++ b/visionatrix/routes/tasks.py
@@ -117,10 +117,10 @@ async def create_task(
         flow_input_params[input_param["name"]] = input_param
 
     for key in form_data:
-        if key in TaskCreationWithFullParams.model_fields:
-            continue
         if flow.is_seed_supported and key == "seed":
             in_text_params["seed"] = int(form_data.get(key))
+            continue
+        if key in TaskCreationWithFullParams.model_fields:
             continue
         if key not in flow_input_params:
             LOGGER.warning("Unexpected parameter '%s' for '%s' task creation, ignoring.", key, name)


### PR DESCRIPTION
Although we support this parameter, it is not in the OpenAPI documentation generated for flows.

This PR fixes this, the seed will appear only for workflows that have seed support.