### PR TITLE
disable automatic update checks of "Albumentations" package

### DIFF
--- a/visionatrix/comfyui.py
+++ b/visionatrix/comfyui.py
@@ -34,6 +34,8 @@ TORCH_VERSION: str | None = None
 
 def load(task_progress_callback) -> [typing.Callable[[dict], tuple[bool, dict, list, list]], typing.Any]:
 
+    os.environ["NO_ALBUMENTATIONS_UPDATE"] = "1"  # disable checking if a new version of "Albumentations" is available
+
     sys.path.append(options.BACKEND_DIR)
 
     no_device_detection = "--disable-device-detection" in sys.argv


### PR DESCRIPTION
This PR fixes warning that almost always appear and annoys:

```
/home/user/Visionatrix/venv/lib/python3.12/site-packages/albumentations/__init__.py:13: UserWarning: A new version of Albumentations is available: 1.4.21 (you have 1.4.15).
Upgrade using: pip install -U albumentations. To disable automatic update checks, set the environment variable NO_ALBUMENTATIONS_UPDATE to 1.
  check_for_updates()
```

This will also speed up the launch of Visionatrix a little, since there is one less request to pypi.org