### PR TITLE
more correct handling of "default" nodes params

### DIFF
--- a/visionatrix/custom_openapi.py
+++ b/visionatrix/custom_openapi.py
@@ -67,7 +67,12 @@ def create_dynamic_model(flow_definition: Flow) -> type[BaseModel]:
     model_fields = {}
     for param in flow_definition.input_params:
         d_name = param["display_name"]
-        default = param["default"] if param["optional"] else ...
+        if param.get("default"):
+            default = param["default"]
+        elif param["optional"]:
+            default = None
+        else:
+            default = ...
         if param["type"] == "bool":
             model_field = (bool, Field(default, description=d_name))
         elif param["type"] == "list":
@@ -78,7 +83,7 @@ def create_dynamic_model(flow_definition: Flow) -> type[BaseModel]:
                 Field(default, description=d_name, ge=param["min"], le=param["max"], multiple_of=param["step"]),
             )
         elif param["type"] in SUPPORTED_TEXT_TYPES_INPUTS:
-            model_field = (str, Field(d_name, description=d_name))
+            model_field = (str, Field(default, description=d_name))
         elif param["type"] in SUPPORTED_FILE_TYPES_INPUTS:
             if param["type"] in ("image", "image-mask"):
                 model_field = (


### PR DESCRIPTION
We get a slightly more complex algorithm than OpenAPI allows, but we will try to follow it as much as possible.

Changes in this PR:

1. A typo has been fixed, we passed the node description as a default value.
2. If the node has a default value, we consider it optional (this is the logic of the OpenAPI standard)
3. If the node does not have a default value, but has the `optional` flag, we fill in the default value `None`

As far as I understand, this will allow us to follow the OpenAPI standard, and not change the logic of the `optional` flag.