### PR TITLE
Rework: `openapi` cmd

### DIFF
--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -64,15 +64,24 @@ if __name__ == "__main__":
                 help="Filename to save",
                 default="openapi.json",
             )
-            subparser.add_argument("--available", action="store_true", help="Include specs for 'available' flows")
-            subparser.add_argument("--installed", action="store_true", help="Include specs for 'installed' flows")
             subparser.add_argument(
                 "--indentation",
                 type=int,
                 help="Indentation size",
                 default=2,
             )
-            subparser.add_argument("--only-flows", action="store_true", help="Only specs for flows", default=False)
+            subparser.add_argument(
+                "--flows",
+                type=str,
+                help="Flows to include in OpenAPI specs (comma-separated list or '*')",
+                default="",
+            )
+            subparser.add_argument(
+                "--skip-not-installed",
+                action="store_true",
+                help="Skip flows that are not installed",
+                default=True,
+            )
 
         if i[0] == "install-flow":
             install_flow_group = subparser.add_mutually_exclusive_group(required=True)
@@ -227,7 +236,9 @@ if __name__ == "__main__":
         process_orphan_models(args.dry_run, args.no_confirm, args.include_useful_models)
     elif args.command == "openapi":
         comfyui.load(None)
-        openapi_schema = generate_openapi(args.available, args.installed, args.only_flows)
+        flows_arg = args.flows.strip()
+        skip_not_installed = args.skip_not_installed
+        openapi_schema = generate_openapi(flows=flows_arg, skip_not_installed=skip_not_installed)
         with builtins.open(args.file, "w", encoding="UTF-8") as f:
             openapi_schema_str = json.dumps(openapi_schema, indent=args.indentation)
             if not openapi_schema_str.endswith("\n"):

--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -82,6 +82,12 @@ if __name__ == "__main__":
                 help="Skip flows that are not installed",
                 default=True,
             )
+            subparser.add_argument(
+                "--exclude-base",
+                action="store_true",
+                help="Exclude base application endpoints from OpenAPI specs",
+                default=False,
+            )
 
         if i[0] == "install-flow":
             install_flow_group = subparser.add_mutually_exclusive_group(required=True)
@@ -238,7 +244,7 @@ if __name__ == "__main__":
         comfyui.load(None)
         flows_arg = args.flows.strip()
         skip_not_installed = args.skip_not_installed
-        openapi_schema = generate_openapi(flows=flows_arg, skip_not_installed=skip_not_installed)
+        openapi_schema = generate_openapi(flows_arg, skip_not_installed, args.exclude_base)
         with builtins.open(args.file, "w", encoding="UTF-8") as f:
             openapi_schema_str = json.dumps(openapi_schema, indent=args.indentation)
             if not openapi_schema_str.endswith("\n"):

--- a/visionatrix/backend.py
+++ b/visionatrix/backend.py
@@ -145,8 +145,8 @@ def run_vix(*args, **kwargs) -> None:
             print("Visionatrix is shutting down.")
 
 
-def generate_openapi(flows: str = "", skip_not_installed: bool = True):
-    return custom_openapi.generate_openapi(APP, flows=flows, skip_not_installed=skip_not_installed)
+def generate_openapi(flows: str = "", skip_not_installed: bool = True, exclude_base: bool = False):
+    return custom_openapi.generate_openapi(APP, flows, skip_not_installed, exclude_base)
 
 
 APP.openapi = generate_openapi

--- a/visionatrix/backend.py
+++ b/visionatrix/backend.py
@@ -145,8 +145,8 @@ def run_vix(*args, **kwargs) -> None:
             print("Visionatrix is shutting down.")
 
 
-def generate_openapi(available: bool = False, installed: bool = False, only_flows: bool = False):
-    return custom_openapi.generate_openapi(APP, available, installed, only_flows)
+def generate_openapi(flows: str = "", skip_not_installed: bool = True):
+    return custom_openapi.generate_openapi(APP, flows=flows, skip_not_installed=skip_not_installed)
 
 
 APP.openapi = generate_openapi
@@ -154,26 +154,22 @@ APP.openapi = generate_openapi
 
 @APP.get("/openapi/flows.json", include_in_schema=False)
 async def openapi_flows_json(
-    available: bool = Query(False, description="Include available flows"),
-    installed: bool = Query(False, description="Include installed flows"),
-    only_flows: bool = Query(False, description="Include only flow endpoints"),
+    flows: str = Query("", description="Flows to include in OpenAPI specs (comma-separated list or '*')"),
+    skip_not_installed: bool = Query(True, description="Skip flows that are not installed"),
 ):
-    return custom_openapi.generate_openapi(APP, available, installed, only_flows)
+    return custom_openapi.generate_openapi(APP, flows=flows, skip_not_installed=skip_not_installed)
 
 
 @APP.get("/docs/flows", include_in_schema=False)
 async def docs_flows(
-    available: bool = Query(False, description="Include available flows"),
-    installed: bool = Query(True, description="Include installed flows"),
-    only_flows: bool = Query(False, description="Include only flow endpoints"),
+    flows: str = Query("*", description="Flows to include in OpenAPI specs (comma-separated list or '*')"),
+    skip_not_installed: bool = Query(True, description="Skip flows that are not installed"),
 ):
     query_params = []
-    if available:
-        query_params.append("available=true")
-    if installed:
-        query_params.append("installed=true")
-    if only_flows:
-        query_params.append("only_flows=true")
+    if flows:
+        query_params.append(f"flows={flows}")
+    if not skip_not_installed:
+        query_params.append("skip_not_installed=false")
     query_string = "&".join(query_params)
     openapi_url = "/openapi/flows.json"
     if query_string:

--- a/visionatrix/comfyui.py
+++ b/visionatrix/comfyui.py
@@ -100,9 +100,9 @@ def load(task_progress_callback) -> [typing.Callable[[dict], tuple[bool, dict, l
         "--server",
         "--disable-device-detection",
         "^openapi$",
-        "--installed",
-        "--available",
-        "--only-flows",
+        "--skip-not-installed",
+        "--flows",
+        "--exclude-base",
         "--indentation=",
         "visionatrix:APP",
     ]

--- a/visionatrix/custom_openapi.py
+++ b/visionatrix/custom_openapi.py
@@ -136,28 +136,47 @@ def create_dynamic_route(flow_definition: Flow):
     return dynamic_route
 
 
-def generate_openapi(app: FastAPI, available: bool, installed: bool, only_flows: bool = False):
+def generate_openapi(app: FastAPI, flows: str = "", skip_not_installed: bool = True):
     flows_definitions = {}
-    if available:
-        flows_definitions.update(get_available_flows())
-    if installed:
+    if flows == "":
+        # Do not include any flows
+        flows_definitions = {}
+    elif flows == "*":
+        # Include all installed flows
         flows_definitions.update(get_installed_flows())
+        if not skip_not_installed:
+            flows_definitions.update(get_available_flows())
+    else:
+        # flows is a comma-separated list of flow names
+        flow_names = [name.strip() for name in flows.split(",") if name.strip()]
+        # Get installed flows matching these names
+        installed_flows = get_installed_flows()
+        selected_flows = {name: flow for name, flow in installed_flows.items() if name in flow_names}
+        if not skip_not_installed:
+            # Include not installed flows if any of the specified flows are not installed
+            available_flows = get_available_flows()
+            for name in flow_names:
+                if name not in selected_flows and name in available_flows:
+                    selected_flows[name] = available_flows[name]
+        flows_definitions.update(selected_flows)
+
     update_tasks_integrations_routes(app, flows_definitions)
 
-    if only_flows:
+    filtered_routes = app.routes  # By default, include all routes
+
+    # Exclude flow routes when flows == ""
+    if flows == "":
+        # Exclude flow routes
         filtered_routes = []
         for route in app.routes:
-            if (
-                isinstance(route, APIRoute)
-                and route.path.startswith(TASK_CREATE_ROUTE)
-                and not route.path.endswith("{name}")
-            ):
+            if isinstance(route, APIRoute):
+                if not (route.path.startswith(TASK_CREATE_ROUTE) and not route.path.endswith("{name}")):
+                    filtered_routes.append(route)
+            else:
                 filtered_routes.append(route)
-    else:
-        filtered_routes = app.routes
 
     routes_signature = compute_routes_signature(filtered_routes)
-    cache_key = (routes_signature, only_flows)
+    cache_key = (routes_signature, flows, skip_not_installed)
 
     if not hasattr(app, "openapi_schemas"):
         app.openapi_schemas = {}
@@ -185,8 +204,6 @@ def generate_openapi(app: FastAPI, available: bool, installed: bool, only_flows:
                     content_type["multipart/form-data"] = {"schema": form_data_schema}
 
     app.openapi_schemas[cache_key] = openapi_schema
-    if not only_flows:
-        app.openapi_schema = openapi_schema
     return openapi_schema
 
 


### PR DESCRIPTION
The main thing I need now to test one very interesting idea is to generate OpenAPI documentation for all basic endpoints + only 1 selected flow.

The option to delete all flows and leave only 1 and generate for it is clearly very hacky.

Therefore, we quickly rework the "openapi" command, immediately add a clear description to the parameters.