### PR TITLE
specify default param for float, bool, int types

### DIFF
--- a/visionatrix/custom_openapi.py
+++ b/visionatrix/custom_openapi.py
@@ -67,8 +67,9 @@ def create_dynamic_model(flow_definition: Flow) -> type[BaseModel]:
     model_fields = {}
     for param in flow_definition.input_params:
         d_name = param["display_name"]
-        if param.get("default"):
-            default = param["default"]
+        default_param = param.get("default")
+        if (isinstance(default_param, str) and default_param) or isinstance(default_param, float | int | bool):
+            default = default_param
         elif param["optional"]:
             default = None
         else:


### PR DESCRIPTION
Example of OpenAPI generation before these changes:


```python

"realism_lora_strength": {
            "type": "number",
            "multipleOf": 0.1,
            "maximum": 1.0,
            "minimum": 0.0,
            "title": "Realism Lora Strength",
            "description": "Realism LoRa strength"
          }
```
          
```python                  
"fast_run": {
            "type": "boolean",
            "title": "Fast Run",
            "description": "Fast run"
          }                
```

With this PR:

```python3
"realism_lora_strength": {
            "type": "number",
            "multipleOf": 0.1,
            "maximum": 1.0,
            "minimum": 0.0,
            "title": "Realism Lora Strength",
            "description": "Realism LoRa strength",
            "default": 0
          }
```

```python3
"fast_run": {
            "type": "boolean",
            "title": "Fast Run",
            "description": "Fast run",
            "default": false
          }
```

Although, as for me, it is still a bit mess until we add that the "default" parameter can be omitted from the ComfyUI flow itself in the node.

Currently we can either fill it in or leave it empty, it doesn't have the Python `None` value there.

But for now it will do, it covers all our current needs, since we are trying to write workflows to be easy to use, so it is possible that we won't have to change anything in the future          