### PR TITLE
bumped cuda from `12.1` to `12.4` version

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "visionatrix",
-    "version": "1.7.0.dev0"
+    "version": "1.8.0.dev0"
   },
   "paths": {
     "/vapi/flows/installed": {
@@ -3476,7 +3476,7 @@
             "format": "date-time",
             "title": "Last Seen",
             "description": "Last seen time",
-            "default": "2024-11-23T07:49:29.485081Z"
+            "default": "2024-11-23T15:44:53.518841Z"
           },
           "engine_details": {
             "$ref": "#/components/schemas/ComfyEngineDetails"

--- a/scripts/easy_install.py
+++ b/scripts/easy_install.py
@@ -244,7 +244,7 @@ def install_graphics_card_packages():
         print("Installing packages for NVIDIA graphics card...")
         if sys.platform.lower() == "win32":
             venv_run(
-                pip_install + "torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121"
+                pip_install + "torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124"
             )  # noqa # !!! do not forget to change PyTorch version in `visionatrix/comfyui.py` !!!
         else:
             venv_run(pip_install + "torch torchvision torchaudio")

--- a/visionatrix/_version.py
+++ b/visionatrix/_version.py
@@ -1,3 +1,3 @@
 """Version of Visionatrix"""
 
-__version__ = "1.7.0"
+__version__ = "1.8.0.dev0"

--- a/visionatrix/comfyui.py
+++ b/visionatrix/comfyui.py
@@ -61,7 +61,7 @@ def load(task_progress_callback) -> [typing.Callable[[dict], tuple[bool, dict, l
                         "torchvision",
                         "torchaudio",
                         "--index-url",
-                        "https://download.pytorch.org/whl/cu121",
+                        "https://download.pytorch.org/whl/cu124",
                         # !!! do not forget to change PyTorch version in "scripts/easy_install.py" !!!
                     ]
                 )


### PR DESCRIPTION
So, let's start relaxed development of the next version of Visionatrix with a release in about 9 days.

Time to bump default CUDA that is installing for the new systems.

PyTorch stopped building new wheels for `12.1` here is [post](https://github.com/pytorch/pytorch/issues/138609#issuecomment-2494607809) from their repo