### PR TITLE
Fix installing models from "zip" archives

### DIFF
--- a/.github/workflows/tests-flows-install.yml
+++ b/.github/workflows/tests-flows-install.yml
@@ -1,0 +1,57 @@
+name: Flows Install
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flows_install-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  github_flows_install_linux:
+    name: Flows Install GitHub Ubuntu 22
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+    env:
+      DATABASE_URI: postgresql+psycopg://vix_user:vix_password@localhost:5432/vix_db
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: vix_user
+          POSTGRES_PASSWORD: vix_password
+          POSTGRES_DB: vix_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Visionatrix dependencies
+        run: |
+          python3 -m pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+          python3 -m pip install ".[pgsql]"
+
+      - name: Run Visionatrix install
+        run: python3 -m visionatrix install
+
+      - name: Install flows from CMD
+        run: |
+          echo "Y" | VIX_MODE=SERVER VIX_SERVER_FULL_MODELS=0 python3 -m visionatrix install-flow --name=*

--- a/.github/workflows/tests-flows-run.yml
+++ b/.github/workflows/tests-flows-run.yml
@@ -1,4 +1,4 @@
-name: Test install
+name: Flows Run
 
 on:
   pull_request:
@@ -9,12 +9,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: test_install-${{ github.head_ref || github.run_id }}
+  group: flows_run-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  install_macos_github:
-    name: GitHub macOS:14
+  github_flows_run_macos:
+    name: Flows Run GitHub macOS 14
     runs-on: macos-14
     strategy:
       fail-fast: false
@@ -36,8 +36,8 @@ jobs:
       - name: Perform Tensor tests
         run: python3 tests/rm_background_bria.py
 
-  install_linux_github:
-    name: GitHub Ubuntu:22
+  github_flows_run_linux:
+    name: Flows Run GitHub Ubuntu 22
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -59,8 +59,8 @@ jobs:
       - name: Perform Tensor tests
         run: python3 tests/rm_background_bria.py
 
-  install_windows_github:
-    name: GitHub Windows:2019
+  github_flows_run_windows:
+    name: Flows Run GitHub Windows 2019
     runs-on: windows-2019
     strategy:
       fail-fast: false


### PR DESCRIPTION
In this pull request https://github.com/Visionatrix/Visionatrix/pull/244 , which heavily refactored the installation of flows and models, an error was found that appeared in the CI repo with docs.

I managed to repeat it locally - the error is that it is incorrectly determined whether the models from zip archives are installed.

Changes in this PR on this topic:

* Models in 'zip' archives are always downloaded, even with the flag VIX_SERVER_FULL_MODELS=0
* A basic test has been added for now (for installing all flows in server mode), so that CI in this repo does not allow defective PRs to be merged