### PR TITLE
(fix): dynamic calculation of models paths

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2033,13 +2033,20 @@
             "title": "Name",
             "description": "Unique name of the model."
           },
-          "paths": {
+          "types": {
             "items": {
               "type": "string"
             },
             "type": "array",
-            "title": "Paths",
-            "description": "Paths where the model can be stored within the filesystem."
+            "title": "Types",
+            "description": "ComfyUI model types to which model belongs(e.g 'checkpoints', 'loras').",
+            "default": []
+          },
+          "filename": {
+            "type": "string",
+            "title": "Filename",
+            "description": "Overridden file name under which the model can be found in the file system.",
+            "default": ""
           },
           "url": {
             "type": "string",
@@ -2082,7 +2089,6 @@
         "type": "object",
         "required": [
           "name",
-          "paths",
           "url",
           "hash"
         ],
@@ -3723,7 +3729,7 @@
             "format": "date-time",
             "title": "Last Seen",
             "description": "Last seen time",
-            "default": "2024-12-01T08:34:35.922605Z"
+            "default": "2024-12-03T13:17:55.801258Z"
           },
           "engine_details": {
             "$ref": "#/components/schemas/ComfyEngineDetails"

--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -9,28 +9,28 @@ BASIC_NODE_LIST = {
         "models": [
             AIResourceModel(
                 name="sam_vit_b_01ec64",
-                paths="models/sams/sam_vit_b_01ec64.pth",
+                filename="models/sams/sam_vit_b_01ec64.pth",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/sams/sam_vit_b_01ec64.pth",
                 homepage="https://github.com/facebookresearch/segment-anything",
                 hash="ec2df62732614e57411cdcf32a23ffdf28910380d03139ee0f4fcbe91eb8c912",
             ),
             AIResourceModel(
                 name="face_yolov8m.pt",
-                paths="models/ultralytics/bbox/face_yolov8m.pt",
+                filename="models/ultralytics/bbox/face_yolov8m.pt",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/ultralytics/bbox/face_yolov8m.pt",
                 homepage="https://huggingface.co/Bingsu/adetailer",
                 hash="f02b8a23e6f12bd2c1b1f6714f66f984c728fa41ed749d033e7d6dea511ef70c",
             ),
             AIResourceModel(
                 name="hand_yolov8s.pt",
-                paths="models/ultralytics/bbox/hand_yolov8s.pt",
+                filename="models/ultralytics/bbox/hand_yolov8s.pt",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/ultralytics/bbox/hand_yolov8s.pt",
                 homepage="https://huggingface.co/Bingsu/adetailer",
                 hash="5c4faf8d17286ace2c3d3346c6d0d4a0c8d62404955263a7ae95c1dd7eb877af",
             ),
             AIResourceModel(
                 name="person_yolov8m-seg.pt",
-                paths="models/ultralytics/segm/person_yolov8m-seg.pt",
+                filename="models/ultralytics/segm/person_yolov8m-seg.pt",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/ultralytics/segm/person_yolov8m-seg.pt",
                 homepage="https://huggingface.co/Bingsu/adetailer",
                 hash="9d881ec50b831f546e37977081b18f4e3bf65664aec163f97a311b0955499795",
@@ -44,7 +44,7 @@ BASIC_NODE_LIST = {
         "models": [
             AIResourceModel(
                 name="antelopev2",
-                paths="models/insightface/models/antelopev2.zip",
+                filename="models/insightface/models/antelopev2.zip",
                 url="https://huggingface.co/MonsterMMORPG/tools/resolve/main/antelopev2.zip",
                 homepage="https://github.com/deepinsight/insightface",
                 hash="8e182f14fc6e80b3bfa375b33eb6cff7ee05d8ef7633e738d1c89021dcf0c5c5",
@@ -62,7 +62,7 @@ BASIC_NODE_LIST = {
         "models": [
             AIResourceModel(
                 name="RMGB-1.4",
-                paths="custom_nodes/ComfyUI-BRIA_AI-RMBG/RMBG-1.4/model.pth",
+                filename="custom_nodes/ComfyUI-BRIA_AI-RMBG/RMBG-1.4/model.pth",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/RMBG-1.4/model.pth",
                 homepage="https://huggingface.co/briaai/RMBG-1.4",
                 hash="893c16c340b1ddafc93e78457a4d94190da9b7179149f8574284c83caebf5e8c",
@@ -73,14 +73,14 @@ BASIC_NODE_LIST = {
         "models": [
             AIResourceModel(
                 name="ComfyUI-BiRefNet-EP480",
-                paths="models/BiRefNet/BiRefNet-ep480.pth",
+                filename="models/BiRefNet/BiRefNet-ep480.pth",
                 url="https://huggingface.co/ViperYX/BiRefNet/resolve/main/BiRefNet-ep480.pth",
                 homepage="https://huggingface.co/ViperYX/BiRefNet",
                 hash="367a738b27e0556e703991e8160fe6b5217bec6c158a72a890d131dd11ba74f6",
             ),
             AIResourceModel(
                 name="ComfyUI-BiRefNet-Swin-Large",
-                paths="models/BiRefNet/swin_large_patch4_window12_384_22kto1k.pth",
+                filename="models/BiRefNet/swin_large_patch4_window12_384_22kto1k.pth",
                 url="https://huggingface.co/ViperYX/BiRefNet/resolve/main/swin_large_patch4_window12_384_22kto1k.pth",
                 homepage="https://huggingface.co/ViperYX/BiRefNet",
                 hash="30762928cd6ee9229e24e26e200951b8fe635799b67db016ba747fa653b64db9",
@@ -120,7 +120,7 @@ BASIC_NODE_LIST = {
         "models": [
             AIResourceModel(
                 name="buffalo_l",
-                paths="models/insightface/models/buffalo_l.zip",
+                filename="models/insightface/models/buffalo_l.zip",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/insightface/buffalo_l.zip",
                 homepage="https://github.com/deepinsight/insightface",
                 hash="80ffe37d8a5940d59a7384c201a2a38d4741f2f3c51eef46ebb28218a7b0ca2f",

--- a/visionatrix/models.py
+++ b/visionatrix/models.py
@@ -12,6 +12,7 @@ import httpx
 from fastapi import status
 
 from . import db_queries, options
+from .models_map import get_possible_paths_for_model
 from .pydantic_models import AIResourceModel, ModelProgressInstall
 
 DOWNLOAD_RETRY_COUNT = 3
@@ -93,7 +94,7 @@ def install_model(
         return False
 
     # Proceed to install the model
-    save_path = Path(model.paths[0])
+    save_path = Path(get_possible_paths_for_model(model)[0])
     os.makedirs(save_path.parent, exist_ok=True)
     for _ in range(DOWNLOAD_RETRY_COUNT):
         LOGGER.info("Downloading `%s`..", model.name)
@@ -263,7 +264,7 @@ def prepare_download_headers(model: AIResourceModel, save_path: Path, hf_auth_to
 def is_model_exists_in_fs(
     model: AIResourceModel, flow_name: str, model_progress_install: ModelProgressInstall | None = None
 ) -> bool:
-    for model_paths in model.paths:
+    for model_paths in get_possible_paths_for_model(model):
         save_path = Path(model_paths)
         LOGGER.debug("model=%s --> save_path=%s", model.name, save_path)
         if save_path.exists() and not model.url.endswith(".zip"):

--- a/visionatrix/orphan_models.py
+++ b/visionatrix/orphan_models.py
@@ -5,7 +5,7 @@ from . import options
 from .basic_node_list import BASIC_NODE_LIST
 from .comfyui_wrapper import get_folder_names_and_paths
 from .flows import get_available_flows, get_installed_flows
-from .models_map import get_formatted_models_catalog
+from .models_map import get_formatted_models_catalog, get_possible_paths_for_model
 from .pydantic_models import OrphanModel
 
 
@@ -27,18 +27,18 @@ def get_orphan_models() -> list[OrphanModel]:
     required_models = {}
     for flow in installed_flows.values():
         for model in flow.models:
-            for i in model.paths:
+            for i in get_possible_paths_for_model(model):
                 required_models[str(Path(i))] = model
 
     all_known_models = {}
     for model in get_formatted_models_catalog():
-        for i in model.paths:
+        for i in get_possible_paths_for_model(model):
             all_known_models[str(Path(i))] = model
 
     models_to_flows_map = {}
     for flow in all_known_flows.values():
         for model in flow.models:
-            model_save_paths = {str(Path(i)) for i in model.paths}
+            model_save_paths = {str(Path(i)) for i in get_possible_paths_for_model(model)}
             for model_save_path in model_save_paths:
                 if model_save_path in models_to_flows_map:
                     models_to_flows_map[model_save_path].append(flow)
@@ -52,7 +52,7 @@ def get_orphan_models() -> list[OrphanModel]:
         if not node_details.get("models"):
             continue
         for model_from_node in node_details["models"]:
-            for i in model_from_node.paths:
+            for i in get_possible_paths_for_model(model_from_node):
                 models_filenames_from_nodes.add(str(Path(i).name))
             for i in model_from_node.hashes:
                 models_filenames_from_nodes.add(i)

--- a/visionatrix/pydantic_models.py
+++ b/visionatrix/pydantic_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Annotated, Any
+from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Self
@@ -38,7 +38,8 @@ class AIResourceModel(BaseModel):
     """
 
     name: str = Field(..., description="Unique name of the model.")
-    paths: list[str] = Field(..., description="Paths where the model can be stored within the filesystem.")
+    types: list[str] = Field([], description="ComfyUI model types to which model belongs(e.g 'checkpoints', 'loras').")
+    filename: str = Field("", description="Overridden file name under which the model can be found in the file system.")
     url: str = Field(..., description="URL from which the model can be downloaded.")
     homepage: str = Field("", description="Webpage with detailed information about the model.")
     hash: str = Field(..., description="SHA256 hash of the model file for integrity verification.")
@@ -57,13 +58,6 @@ class AIResourceModel(BaseModel):
 
     def __eq__(self, other):
         return isinstance(other, AIResourceModel) and self.name == other.name
-
-    @model_validator(mode="before")
-    @classmethod
-    def validator_before(cls, data: Any) -> Any:
-        if isinstance(data, dict) and isinstance(data.get("paths", []), str):
-            data["paths"] = [data["paths"]]
-        return data
 
 
 class Flow(BaseModel):


### PR DESCRIPTION
This PR is a continuation of this one:

https://github.com/Visionatrix/Visionatrix/pull/253

In that PR we introduced the possibility to change ComfyUI paths to models, but without changes in this PR the Visionatrix code does not see the models immediately, because it calculated the paths at startup.

Now the paths will always be calculated dynamically, this is a little more resource-consuming, but logically more correct and should not affect the speed of flow execution at all.