### PR TITLE
Fix SQLite: database is locked

### DIFF
--- a/visionatrix/database.py
+++ b/visionatrix/database.py
@@ -172,7 +172,10 @@ def init_database_engine() -> None:
     connect_args = {}
     database_uri = options.DATABASE_URI
     if database_uri.startswith("sqlite:"):
-        connect_args = {"check_same_thread": False}
+        connect_args = {
+            "check_same_thread": False,
+            "timeout": 5,
+        }
         if database_uri.startswith("sqlite:///."):
             database_uri = f"sqlite:///{os.path.abspath(os.path.join(os.getcwd(), database_uri[10:]))}"
     engine = create_engine(database_uri, connect_args=connect_args)

--- a/visionatrix/db_queries.py
+++ b/visionatrix/db_queries.py
@@ -436,7 +436,7 @@ def add_model_progress_install(name: str, flow_name: str, filename: str | None =
         session.close()
 
 
-def update_model_progress_install(name: str, flow_name: str, progress: float) -> bool:
+def update_model_progress_install(name: str, flow_name: str, progress: float, not_critical=False) -> bool:
     session = database.SESSION()
     try:
         stmt = (
@@ -452,7 +452,8 @@ def update_model_progress_install(name: str, flow_name: str, progress: float) ->
         session.commit()
 
         if result.rowcount == 0:
-            LOGGER.warning(
+            LOGGER.log(
+                logging.INFO if not_critical else logging.ERROR,
                 "Model installation progress not updated for `%s`. Either it doesn't exist or already has an error.",
                 name,
             )

--- a/visionatrix/models.py
+++ b/visionatrix/models.py
@@ -396,7 +396,7 @@ def check_model_file(
                 if not db_queries.add_model_progress_install(model.name, flow_name, model_filename):
                     db_queries.reset_model_progress_install_error(model.name, flow_name)
             db_queries.update_model_mtime(model.name, model_existing_path.stat().st_mtime, new_filename=model_filename)
-            db_queries.update_model_progress_install(model.name, flow_name, 100.0)
+            db_queries.update_model_progress_install(model.name, flow_name, 100.0, not_critical=True)
             return True
     return False
 
@@ -447,7 +447,7 @@ def lookup_for_model_file_in_directory(
                             flow_name,
                             new_filename=model_filename,
                         )
-                        db_queries.update_model_progress_install(model.name, flow_name, 100.0)
+                        db_queries.update_model_progress_install(model.name, flow_name, 100.0, not_critical=True)
                         return True
     return False
 


### PR DESCRIPTION
Should fix an error that could occur on some hardware (I couldn't reproduce it on mine):

`(sqlite3.OperationalError) database is locked`

when installing flows in parallel.