### PR TITLE
store "sam_vit_b_01ec64.pth" in a correct external models dir

### DIFF
--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -20,10 +20,10 @@ BASIC_NODE_LIST = {
             ),
             AIResourceModel(
                 name="sam_vit_b_01ec64",
-                filename="models/sams/sam_vit_b_01ec64.pth",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/sams/sam_vit_b_01ec64.pth",
                 homepage="https://github.com/facebookresearch/segment-anything",
                 hash="ec2df62732614e57411cdcf32a23ffdf28910380d03139ee0f4fcbe91eb8c912",
+                types=["sams"],
             ),
         ],
     },


### PR DESCRIPTION
Found why we couldn't do this before:

The `comfyui-art-venture` node overwrites the `sams` value of the directory inside ComfyUI and what we specify via the standard legal method using the ]extra_model_paths.yaml] file didn't work.

This PR fixes it, until it's merged I just made the same commit to our fork:
https://github.com/sipherxyz/comfyui-art-venture/pull/69

Now in new installs `sam_vit_b_01ec64.pth`  file will be correctly placed file in the normal "external" directory.