### PR TITLE
 mapping to "ultralytics_bbox" + segm folders

### DIFF
--- a/scripts/easy_install.py
+++ b/scripts/easy_install.py
@@ -361,6 +361,8 @@ vix_models:
   sams: sams
   style_models: style_models
   ultralytics: ultralytics
+  ultralytics_bbox: ultralytics/bbox
+  ultralytics_segm: ultralytics/segm
   upscale_models: upscale_models
   vae: vae
   vae_approx: vae_approx

--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -34,24 +34,24 @@ BASIC_NODE_LIST = {
         "models": [
             AIResourceModel(
                 name="face_yolov8m",
-                filename="models/ultralytics/bbox/face_yolov8m.pt",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/ultralytics/bbox/face_yolov8m.pt",
                 homepage="https://huggingface.co/Bingsu/adetailer",
                 hash="f02b8a23e6f12bd2c1b1f6714f66f984c728fa41ed749d033e7d6dea511ef70c",
+                types=["ultralytics_bbox"],
             ),
             AIResourceModel(
                 name="hand_yolov8s",
-                filename="models/ultralytics/bbox/hand_yolov8s.pt",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/ultralytics/bbox/hand_yolov8s.pt",
                 homepage="https://huggingface.co/Bingsu/adetailer",
                 hash="5c4faf8d17286ace2c3d3346c6d0d4a0c8d62404955263a7ae95c1dd7eb877af",
+                types=["ultralytics_bbox"],
             ),
             AIResourceModel(
                 name="person_yolov8m-seg",
-                filename="models/ultralytics/segm/person_yolov8m-seg.pt",
                 url="https://huggingface.co/andrey18106/visionatrix_models/resolve/main/ultralytics/segm/person_yolov8m-seg.pt",
                 homepage="https://huggingface.co/Bingsu/adetailer",
                 hash="9d881ec50b831f546e37977081b18f4e3bf65664aec163f97a311b0955499795",
+                types=["ultralytics_segm"],
             ),
         ],
     },

--- a/visionatrix/settings_comfyui.py
+++ b/visionatrix/settings_comfyui.py
@@ -86,6 +86,8 @@ def autoconfigure_model_folders(models_dir: str) -> list[ComfyUIFolderPathDefini
         "sams": "sams",
         "style_models": "style_models",
         "ultralytics": "ultralytics",
+        "ultralytics_bbox": "ultralytics/bbox",
+        "ultralytics_segm": "ultralytics/segm",
         "unet": "unet",
         "upscale_models": "upscale_models",
         "vae": "vae",


### PR DESCRIPTION
I found a good issue (https://github.com/ltdrdata/ComfyUI-Impact-Pack/issues/478) + looked into the node sources and realized that we can also store these models correctly.

My extra-path .yamlnow looks like this(this is the default one created by Visionatrix 1.9):


```yaml

vix_models:
  is_default: true
  base_path: ../VixModels
  checkpoints: checkpoints
  text_encoders: text_encoders
  clip_vision: clip_vision
  controlnet: controlnet
  diffusion_models: diffusion_models
  diffusers: diffusers
  ipadapter: ipadapter
  instantid: instantid
  loras: |
    photomaker
    loras
  photomaker: photomaker
  sams: sams
  style_models: style_models
  ultralytics: ultralytics
  ultralytics_bbox: ultralytics/bbox
  ultralytics_segm: ultralytics/segm
  upscale_models: upscale_models
  vae: vae
  vae_approx: vae_approx
  pulid: pulid
  ```
