### PR TITLE
support for "ComfyUI_BiRefNet_ll" node

### DIFF
--- a/.github/workflows/embedded-windows.yml
+++ b/.github/workflows/embedded-windows.yml
@@ -77,7 +77,7 @@ jobs:
         shell: bash
         run: |
           cd vix_portable
-          ./python_embeded/python.exe ../tests/rm_background_bria.py
+          ./python_embeded/python.exe ../tests/rm_background.py
 
       - name: Upload to Artifacts
         if: ${{ always() && github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/tests-flows-run.yml
+++ b/.github/workflows/tests-flows-run.yml
@@ -14,8 +14,8 @@ concurrency:
 
 jobs:
   github_flows_run_macos:
-    name: Flows Run GitHub macOS 14
-    runs-on: macos-14
+    name: Flows Run GitHub macOS 15
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
@@ -37,7 +37,7 @@ jobs:
         run: AUTO_INIT_CONFIG_MODELS_DIR=./vix_models python3 scripts/easy_install.py
 
       - name: Perform Tensor tests
-        run: python3 tests/rm_background_bria.py
+        run: python3 tests/rm_background.py
 
   github_flows_run_linux:
     name: Flows Run GitHub Ubuntu 22
@@ -63,7 +63,7 @@ jobs:
         run: AUTO_INIT_CONFIG_MODELS_DIR=./vix_models python3 scripts/easy_install.py
 
       - name: Perform Tensor tests
-        run: python3 tests/rm_background_bria.py
+        run: python3 tests/rm_background.py
 
   github_flows_run_windows:
     name: Flows Run GitHub Windows 2019
@@ -91,4 +91,4 @@ jobs:
           AUTO_INIT_CONFIG_MODELS_DIR: vix_models
 
       - name: Perform Tensor tests
-        run: python3 tests/rm_background_bria.py
+        run: python3 tests/rm_background.py

--- a/.github/workflows/tests-flows-run.yml
+++ b/.github/workflows/tests-flows-run.yml
@@ -13,31 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  github_flows_run_macos:
-    name: Flows Run GitHub macOS 15
-    runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.12"]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install Visionatrix dependencies
-        run: python3 -m pip install .
-
-      - name: Run Visionatrix install
-        run: python3 -m visionatrix install
-
-      - name: Autoconfig Models Paths
-        run: AUTO_INIT_CONFIG_MODELS_DIR=./vix_models python3 scripts/easy_install.py
-
-      - name: Perform Tensor tests
-        run: python3 tests/rm_background.py
+# https://github.com/pytorch/vision/issues/7490
+#  github_flows_run_macos:
+#    name: Flows Run GitHub macOS 15
+#    runs-on: macos-15
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        python-version: ["3.10", "3.12"]
+#
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-python@v5
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#
+#      - name: Install Visionatrix dependencies
+#        run: python3 -m pip install .
+#
+#      - name: Run Visionatrix install
+#        run: python3 -m visionatrix install
+#
+#      - name: Autoconfig Models Paths
+#        run: AUTO_INIT_CONFIG_MODELS_DIR=./vix_models python3 scripts/easy_install.py
+#
+#      - name: Perform Tensor tests
+#        run: python3 tests/rm_background.py
 
   github_flows_run_linux:
     name: Flows Run GitHub Ubuntu 22

--- a/scripts/easy_install.py
+++ b/scripts/easy_install.py
@@ -367,8 +367,10 @@ vix_models:
   vae: vae
   vae_approx: vae_approx
   pulid: pulid
+  birefnet: birefnet
   rmbg: rmbg
 """
+# TO-DO: remove "rmbg" entry from this list in March/April when "1.9" version will be absolute.
 
 
 if __name__ == "__main__":

--- a/tests/rm_background.py
+++ b/tests/rm_background.py
@@ -14,13 +14,13 @@ IMAGE_URLS = [
 
 # Visionatrix details
 VISIONATRIX_HOST = "http://127.0.0.1:8288"
-FLOW_NAME = "remove_background_bria"
+FLOW_NAME = "remove_background_birefnet_lite"
 CREATE_TASK_ENDPOINT = f"/vapi/tasks/create/{FLOW_NAME}"
 GET_TASK_PROGRESS_ENDPOINT = "/vapi/tasks/progress"
 GET_TASK_RESULTS_ENDPOINT = "/vapi/tasks/results"
 WHOAMI_ENDPOINT = "/vapi/other/whoami"
-POLLING_INTERVAL = 3  # Poll every 3 seconds
-MAX_WAIT_TIME = 300  # Wait up to 5 minutes for the server to be ready
+POLLING_INTERVAL = 5  # Poll every 5 seconds
+MAX_WAIT_TIME = 1800  # Wait up to 30 minutes for the server to be ready & finish task
 
 
 def download_images(temp_dir):
@@ -157,7 +157,7 @@ def compare_images(result_path, reference_path):
     print("Comparing images...", flush=True)
     result_image = Image.open(result_path)
     reference_image = Image.open(reference_path)
-    max_epsilon = 0.000024  # 0.000012 is enough, but we'll multiply it by 2 to be sure.
+    max_epsilon = 0.0075  # 0.000024 difference is enough for Linux runners, but on Windows result differs by 0.0074
     assert_image_similar(result_image, reference_image, max_epsilon)
     print("Test passed!", flush=True)
 
@@ -202,9 +202,9 @@ def convert_to_comparable(a, b):
     return new_a, new_b
 
 
-def assert_image_similar(a, b, epsilon=0.0):
-    assert a.mode == b.mode
-    assert a.size == b.size
+def assert_image_similar(a: Image.Image, b: Image.Image, epsilon=0.0):
+    assert a.mode == b.mode, f"Image modes are not the same: {a.mode} != {b.mode}"
+    assert a.size == b.size, f"Image sizes are not the same: {a.size} != {b.size}"
     a, b = convert_to_comparable(a, b)
     diff = 0
     for ach, bch in zip(a.split(), b.split(), strict=False):

--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -83,26 +83,6 @@ BASIC_NODE_LIST = {
             ),
         ],
     },
-    "ComfyUI-BiRefNet": {
-        "models": [
-            AIResourceModel(
-                name="ComfyUI-BiRefNet-EP480",
-                filename="models/BiRefNet/BiRefNet-ep480.pth",
-                url="https://huggingface.co/ViperYX/BiRefNet/resolve/main/BiRefNet-ep480.pth",
-                homepage="https://huggingface.co/ViperYX/BiRefNet",
-                hash="367a738b27e0556e703991e8160fe6b5217bec6c158a72a890d131dd11ba74f6",
-                file_size=848968257,
-            ),
-            AIResourceModel(
-                name="ComfyUI-BiRefNet-Swin-Large",
-                filename="models/BiRefNet/swin_large_patch4_window12_384_22kto1k.pth",
-                url="https://huggingface.co/ViperYX/BiRefNet/resolve/main/swin_large_patch4_window12_384_22kto1k.pth",
-                homepage="https://huggingface.co/ViperYX/BiRefNet",
-                hash="30762928cd6ee9229e24e26e200951b8fe635799b67db016ba747fa653b64db9",
-                file_size=800688955,
-            ),
-        ],
-    },
     "efficiency-nodes-comfyui": {
         "requirements": {
             "simpleeval": {},
@@ -168,4 +148,5 @@ BASIC_NODE_LIST = {
     "ComfyUI-KJNodes": {},
     "ComfyUI_LayerStyle": {},
     "ComfyUI-Easy-Use": {},
+    "ComfyUI_BiRefNet_ll": {},
 }

--- a/visionatrix/models_map.py
+++ b/visionatrix/models_map.py
@@ -169,6 +169,12 @@ MODEL_LOAD_CLASSES = {
             "preset": True,
         },
     },
+    "LoadRembgByBiRefNetModel": {
+        "1": {
+            "path": ["inputs", "model"],
+            "type": "birefnet",
+        },
+    },
 }
 MODELS_CATALOG: dict[str, dict] = {}
 

--- a/visionatrix/settings_comfyui.py
+++ b/visionatrix/settings_comfyui.py
@@ -93,7 +93,7 @@ def autoconfigure_model_folders(models_dir: str) -> list[ComfyUIFolderPathDefini
         "vae": "vae",
         "vae_approx": "vae_approx",
         "pulid": "pulid",
-        "rmbg": "rmbg",
+        "birefnet": "birefnet",
     }
 
     comfyui_folders = []


### PR DESCRIPTION
Reference: https://github.com/Visionatrix/VixFlowsDocs/pull/71

In short - **this is the very node we've been looking for for so long**, with support for everything we need and working as expected.

I'm so delighted with this node that I even created a [thank you note](https://github.com/lldacing/ComfyUI_BiRefNet_ll/issues/13) for it in their repository.

Update Note
------------------
Those who will update Visionatrix `1.9` to Visionatrix `1.10` need to edit `extra_model_paths.yaml`, if you have it in your Visionatrix or ComfyUI folder, and replace the line with `rmbg` with the line with `birefnet`.