### PR TITLE
macOS: test rmbg on old BiRefNet model

### DIFF
--- a/.github/workflows/tests-flows-run.yml
+++ b/.github/workflows/tests-flows-run.yml
@@ -13,32 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-# https://github.com/pytorch/vision/issues/7490
-#  github_flows_run_macos:
-#    name: Flows Run GitHub macOS 15
-#    runs-on: macos-15
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        python-version: ["3.10", "3.12"]
-#
-#    steps:
-#      - uses: actions/checkout@v4
-#      - uses: actions/setup-python@v5
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#
-#      - name: Install Visionatrix dependencies
-#        run: python3 -m pip install .
-#
-#      - name: Run Visionatrix install
-#        run: python3 -m visionatrix install
-#
-#      - name: Autoconfig Models Paths
-#        run: AUTO_INIT_CONFIG_MODELS_DIR=./vix_models python3 scripts/easy_install.py
-#
-#      - name: Perform Tensor tests
-#        run: python3 tests/rm_background.py
+  github_flows_run_macos:
+    name: Flows Run GitHub macOS 15
+    runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Visionatrix dependencies
+        run: python3 -m pip install .
+
+      - name: Run Visionatrix install
+        run: python3 -m visionatrix install
+
+      - name: Autoconfig Models Paths
+        run: AUTO_INIT_CONFIG_MODELS_DIR=./vix_models python3 scripts/easy_install.py
+
+      - name: Perform Tensor tests
+        run: python3 tests/rm_background_birefnet1.py
+        # We are not testing BiRefNet2 on macOS until this issue is resolved: https://github.com/pytorch/vision/issues/7490
 
   github_flows_run_linux:
     name: Flows Run GitHub Ubuntu 22

--- a/tests/rm_background_birefnet1.py
+++ b/tests/rm_background_birefnet1.py
@@ -9,12 +9,12 @@ from PIL import Image, ImageMath
 # URLs to download images
 IMAGE_URLS = [
     "https://github.com/Visionatrix/VixFlowsDocs/blob/main/tests_data/source-cube_rm_background.png?raw=true",
-    "https://github.com/Visionatrix/VixFlowsDocs/blob/main/tests_data/result-cube_rm_background.png?raw=true"
+    "https://github.com/Visionatrix/VixFlowsDocs/blob/main/tests_data/result-cube_rm_background-birefnet1.png?raw=true"
 ]
 
 # Visionatrix details
 VISIONATRIX_HOST = "http://127.0.0.1:8288"
-FLOW_NAME = "remove_background_birefnet2_lite"
+FLOW_NAME = "remove_background_birefnet"
 CREATE_TASK_ENDPOINT = f"/vapi/tasks/create/{FLOW_NAME}"
 GET_TASK_PROGRESS_ENDPOINT = "/vapi/tasks/progress"
 GET_TASK_RESULTS_ENDPOINT = "/vapi/tasks/results"


### PR DESCRIPTION
We have suck issue related to PyTorch missing support on macOS for new BiRefNet models:

https://github.com/pytorch/vision/issues/7490


**We can't** release version `1.10` and say that on macOS it doesn't work in half of the flows where we use background removal.

And in the next 2 months this won't be fixed, and we won't abandon the new node and switch to the old ones that don't support the configuration where the model is located.

Luckily for us, the new node also supports the old BiRefNet model, we will transfer all the flows where background removal is needed to it for now.

And i**n the description of BiRefNet2 and Bria2 flows** we will simply indicate that they don't work on macOS in the description, on macOS for now there will only be one working flow for background removal.