### PR TITLE
use the latest version of pytorch in new installations

### DIFF
--- a/scripts/easy_install.py
+++ b/scripts/easy_install.py
@@ -250,12 +250,12 @@ def install_graphics_card_packages():
         if sys.platform.lower() == "win32":
             venv_run(pip_install + "torch-directml")
         else:
-            venv_run(pip_install + "torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2")
+            venv_run(pip_install + "torch torchvision torchaudio --index-url https://download.pytorch.org/whl/rocm6.2.4")
     elif c == "nvidia":
         print("Installing packages for NVIDIA graphics card...")
         if sys.platform.lower() == "win32":
             venv_run(
-                pip_install + "torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124"
+                pip_install + "torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126"
             )  # noqa # !!! do not forget to change PyTorch version in `visionatrix/comfyui_wrapper.py` !!!
         else:
             venv_run(pip_install + "torch torchvision torchaudio")

--- a/visionatrix/comfyui_wrapper.py
+++ b/visionatrix/comfyui_wrapper.py
@@ -73,7 +73,7 @@ def load(task_progress_callback) -> [typing.Callable[[dict], tuple[bool, dict, l
                         "torchvision",
                         "torchaudio",
                         "--index-url",
-                        "https://download.pytorch.org/whl/cu124",
+                        "https://download.pytorch.org/whl/cu126",
                         # !!! do not forget to change PyTorch version in "scripts/easy_install.py" !!!
                     ]
                 )


### PR DESCRIPTION
1. CUDA 12.4 --> CUDA 12.6
2. ROCM 6.2  --> ROCM 6.2.4

@andrey18106 please, approve this only after you test that on your GPU nothing breaks with `CUDA 12.6`

P.S: upcoming new benchmarks will be done after this PR, a few days later.