### PR TITLE
disable ComfyUI response compression

### DIFF
--- a/visionatrix/comfyui_wrapper.py
+++ b/visionatrix/comfyui_wrapper.py
@@ -195,6 +195,8 @@ def load(task_progress_callback) -> [typing.Callable[[dict], tuple[bool, dict, l
             call_on_start=None,
         )
 
+    main.args.disable_compres_response_body = True  # disable ComfyUI response compression
+
     return execution.validate_prompt, [q, prompt_server], start_all
 
 


### PR DESCRIPTION
I don't quite understand why they put everything that can be easily and professionally done with reverse proxies into ComfyUI, but that's their choice.

We just disable this feature completely, as it doesn't needed from our point of view.

Reference: https://github.com/comfyanonymous/ComfyUI/pull/6672