### PR TITLE
fix: restore original cmd args, after ComfyUI import

### DIFF
--- a/visionatrix/comfyui_wrapper.py
+++ b/visionatrix/comfyui_wrapper.py
@@ -90,6 +90,8 @@ async def load(
 
     sys.path.append(options.COMFYUI_DIR)
 
+    original_argv = sys.argv[:]
+
     no_device_detection = "--disable-device-detection" in sys.argv
     filter_list = [
         "--host",
@@ -197,6 +199,7 @@ async def load(
             call_on_start=None,
         )
 
+    sys.argv = original_argv
     return execution.validate_prompt, [q, prompt_server], start_all
 
 


### PR DESCRIPTION
One of the users reported that ComfyUI-Manager does not filly work for our project.

This PR and PR in the [ComfyUI-Manager repository](https://github.com/ltdrdata/ComfyUI-Manager/pull/1578) - fixes this.