### PR TITLE
fix: do not do full reset of installed flows cache after deleting the flow

### DIFF
--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -356,8 +356,10 @@ async def __flow_install_callback(name: str, progress: float, error: str, relati
 
 
 async def uninstall_flow(flow_name: str) -> None:
-    await db_queries.delete_flow_progress_install(flow_name)
-    LAST_GOOD_INSTALLED_FLOWS["update_time"] = 0.0
+    with LOCK_INSTALLED_FLOWS:
+        if await db_queries.delete_flow_progress_install(flow_name):
+            LAST_GOOD_INSTALLED_FLOWS["flows"].pop(flow_name, None)
+            LAST_GOOD_INSTALLED_FLOWS["flows_comfy"].pop(flow_name, None)
 
 
 def prepare_flow_comfy(

--- a/visionatrix/routes/flows.py
+++ b/visionatrix/routes/flows.py
@@ -281,7 +281,7 @@ async def delete(request: Request, name: str = Query(..., description="Name of t
     This endpoint will succeed even if the flow does not exist.
     """
     require_admin(request)
-    await uninstall_flow(name)
+    await uninstall_flow(name.lower())
 
 
 @ROUTER.post(


### PR DESCRIPTION
We have an algorithm that we return the old cache if the update process of cache is in progress, so after deleting flow, UI could display that it was installed - since the backend could sometimes return the old cache value.