### PR TITLE
path rework:  support for Docker setups

### DIFF
--- a/.github/workflows/embedded-windows.yml
+++ b/.github/workflows/embedded-windows.yml
@@ -64,7 +64,7 @@ jobs:
             echo "Detected release version."
             ./python_embeded/python.exe easy_install.py
           fi
-          rm -rf Visionatrix visionatrix.db
+          rm -rf Visionatrix visionatrix.db visionatrix.db-shm visionatrix.db-wal
           ./python_embeded/python.exe -m pip uninstall torch torchaudio torchvision -y
           cd ..
         env:
@@ -76,9 +76,10 @@ jobs:
         run: |
           echo "Listing contents of the 'vix_portable' directory:"
           ls -la vix_portable
+          echo "Listing contents of the 'ComfyUI' directory with folder sizes:"
+          du -sh vix_portable/ComfyUI/* | sort -hr
 
       - name: Archive Vix
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         shell: bash
         run: |
           "C:\Program Files\7-Zip\7z.exe" a -t7z -m0=lzma -mx=8 -mfb=64 -md=32m -ms=on -mf=BCJ2 vix_portable_cuda.7z vix_portable
@@ -91,7 +92,7 @@ jobs:
           ./python_embeded/python.exe ../tests/rm_background.py
 
       - name: Upload to Artifacts
-        if: ${{ always() && github.event_name == 'workflow_dispatch' }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: vix_portable_cuda.7z

--- a/.github/workflows/tests-flows-install.yml
+++ b/.github/workflows/tests-flows-install.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Run Visionatrix install
         run: python3 -m visionatrix install
 
-      - name: Autoconfig Models Paths
-        run: python3 -m visionatrix set-global-setting --key="comfyui_models_folder" --value="./vix_models"
-
       - name: Install flows from CMD
         run: |
           echo "Y" | VIX_MODE=SERVER VIX_SERVER_FULL_MODELS=0 python3 -m visionatrix install-flow --name=*

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ converted/
 geckodriver.log
 
 ComfyUI
+ComfyUI-Data
 vix_models
 vix_tasks_files
 vix_worker_tasks_files

--- a/openapi.json
+++ b/openapi.json
@@ -4358,7 +4358,7 @@
             "format": "date-time",
             "title": "Last Seen",
             "description": "Last seen time",
-            "default": "2025-03-01T11:28:03.432717Z"
+            "default": "2025-03-07T15:42:03.020576Z"
           },
           "engine_details": {
             "$ref": "#/components/schemas/ComfyEngineDetails"

--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -171,6 +171,7 @@ if __name__ == "__main__":
 
     options.init_dirs_values(
         comfyui_dir=asyncio.run(get_global_setting("comfyui_folder", True)),
+        base_data_dir=asyncio.run(get_global_setting("comfyui_base_data_folder", True)),
         input_dir=asyncio.run(get_global_setting("comfyui_input_folder", True)),
         output_dir=asyncio.run(get_global_setting("comfyui_output_folder", True)),
         user_dir=asyncio.run(get_global_setting("comfyui_user_folder", True)),

--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -56,18 +56,21 @@ if __name__ == "__main__":
             subparser.add_argument("--disabled", type=bool, help="Should account be disabled", default=False)
             continue
 
-        if i[0] == "orphan-models":
+        if i[0] == "list-global-settings":
+            continue
+        if i[0] == "get-global-setting":
+            subparser.add_argument("--key", required=True, help="Name of the global setting")
+            continue
+        if i[0] == "set-global-setting":
+            subparser.add_argument("--key", required=True, help="Name of the global setting")
+            subparser.add_argument("--value", required=True, help="Value of the global setting")
             subparser.add_argument(
-                "--no-confirm", action="store_true", help="Do not ask for confirmation for each model"
-            )
-            subparser.add_argument(
-                "--dry-run", action="store_true", help="Perform cleaning without actual removing models"
-            )
-            subparser.add_argument(
-                "--include-useful-models",
+                "--sensitive",
                 action="store_true",
-                help="Include orphaned models that can be used in future flows for removal",
+                default=False,
+                help="Whether this setting is sensitive (hidden for non-admins)",
             )
+            continue
 
         if i[0] == "openapi":
             subparser.add_argument(
@@ -101,6 +104,19 @@ if __name__ == "__main__":
                 default=False,
             )
 
+        if i[0] == "orphan-models":
+            subparser.add_argument(
+                "--no-confirm", action="store_true", help="Do not ask for confirmation for each model"
+            )
+            subparser.add_argument(
+                "--dry-run", action="store_true", help="Perform cleaning without actual removing models"
+            )
+            subparser.add_argument(
+                "--include-useful-models",
+                action="store_true",
+                help="Include orphaned models that can be used in future flows for removal",
+            )
+
         if i[0] == "install-flow":
             install_flow_group = subparser.add_mutually_exclusive_group(required=True)
             install_flow_group.add_argument(
@@ -111,24 +127,10 @@ if __name__ == "__main__":
             install_flow_group.add_argument("--name", type=str, help="Flow name mask of the flow(s)")
             install_flow_group.add_argument("--tag", type=str, help="Flow tags mask of the flow(s)")
 
-        if i[0] == "get-global-setting":
-            subparser.add_argument("--key", required=True, help="Name of the global setting")
-        elif i[0] == "set-global-setting":
-            subparser.add_argument("--key", required=True, help="Name of the global setting")
-            subparser.add_argument("--value", required=True, help="Value of the global setting")
-            subparser.add_argument(
-                "--sensitive",
-                action="store_true",
-                default=False,
-                help="Whether this setting is sensitive (hidden for non-admins)",
-            )
-
-        subparser.add_argument("--comfyui_dir", type=str, help="ComfyUI directory")
         if i[0] == "run":
             subparser.add_argument("--host", type=str, help="Host to listen (DEFAULT or SERVER mode)")
             subparser.add_argument("--port", type=str, help="Port to listen (DEFAULT or SERVER mode)")
             subparser.add_argument("--server", type=str, help="Address of Vix Server (WORKER mode)")
-            subparser.add_argument("--tasks_files_dir", type=str, help="Directory for input/output files")
             subparser.add_argument("--mode", choices=["WORKER", "SERVER"], help="VIX special operating mode")
             subparser.add_argument("--ui", nargs="?", default="", help="Enable WebUI (DEFAULT or SERVER mode)")
             subparser.add_argument("--disable-device-detection", action="store_true", default=False)
@@ -168,31 +170,12 @@ if __name__ == "__main__":
         sys.exit(0)
 
     options.init_dirs_values(
-        comfyui=getattr(args, "comfyui_dir", ""),
-        tasks_files=getattr(args, "tasks_files_dir", ""),
+        comfyui_dir=asyncio.run(get_global_setting("comfyui_folder", True)),
+        input_dir=asyncio.run(get_global_setting("comfyui_input_folder", True)),
+        output_dir=asyncio.run(get_global_setting("comfyui_output_folder", True)),
+        user_dir=asyncio.run(get_global_setting("comfyui_user_folder", True)),
+        models_dir=asyncio.run(get_global_setting("comfyui_models_folder", True)),
     )
-
-    model_path_optional = args.command in (
-        "install",
-        "openapi",
-        "list-global-settings",
-        "get-global-setting",
-        "set-global-setting",
-    )
-    comfyui_wrapper.COMFYUI_MODELS_FOLDER = asyncio.run(get_global_setting("comfyui_models_folder", True))
-    if not comfyui_wrapper.COMFYUI_MODELS_FOLDER:
-        folder_path = os.environ.get("COMFYUI_MODEL_PATH", "")
-        if not folder_path and not model_path_optional:
-            folder_path = input(
-                "The 'comfyui_models_folder' setting is not set. Please specify the path(relative or absolute): "
-            ).strip()
-        if not folder_path and not model_path_optional:
-            print("No path provided. 'comfyui_models_folder' remains unset. Exit.")
-            sys.exit(2)
-        if folder_path:
-            asyncio.run(set_global_setting("comfyui_models_folder", folder_path, False))
-            comfyui_wrapper.COMFYUI_MODELS_FOLDER = folder_path
-            print(f"'comfyui_models_folder' set to: {folder_path}")
 
     if args.command == "install":
         comfyui_dir = Path(options.COMFYUI_DIR)
@@ -201,13 +184,12 @@ if __name__ == "__main__":
             if c != "y":
                 print("Skipping ComfyUI re-installation.")
                 sys.exit(0)
-            comfyui_models = comfyui_dir.joinpath("models")
-            comfyui_models_size = sum(file.stat().st_size for file in comfyui_models.rglob("*") if file.is_file())
-            comfyui_models_size_gb = round(comfyui_models_size / (1024**3), 1)
-            logging.getLogger("visionatrix").debug("Size of ComfyUI/models dir: %s GB", comfyui_models_size_gb)
-            if comfyui_models_size_gb > 3.9:  # Threshold in GB
+            comfyui_folder_size = sum(file.stat().st_size for file in comfyui_dir.rglob("*") if file.is_file())
+            comfyui_folder_size_gb = round(comfyui_folder_size / (1024**3), 1)
+            logging.getLogger("visionatrix").debug("Size of ComfyUI dir: %s GB", comfyui_folder_size_gb)
+            if comfyui_folder_size_gb > 3.9:  # Threshold in GB
                 c = input(
-                    f"The ComfyUI models folder is approximately {comfyui_models_size_gb} GB. "
+                    f"The ComfyUI folder is approximately {comfyui_folder_size_gb} GB. "
                     "Are you sure you want to proceed and clear this folder? (Y/N): "
                 ).lower()
                 if c != "y":

--- a/visionatrix/backend.py
+++ b/visionatrix/backend.py
@@ -175,8 +175,8 @@ def run_vix(*args, **kwargs) -> None:
         LOGGER.error("`WORKER` mode is incompatible with UI")
         return
 
-    for i in ("input", "output"):
-        os.makedirs(os.path.join(options.TASKS_FILES_DIR, i), exist_ok=True)
+    os.makedirs(options.INPUT_DIR, exist_ok=True)
+    os.makedirs(options.OUTPUT_DIR, exist_ok=True)
 
     if options.VIX_MODE != "WORKER":
         if options.VIX_MODE == "SERVER":

--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -428,10 +428,10 @@ def prepare_flow_comfy_files_params(
             if not node:
                 raise RuntimeError(f"Bad workflow, node with id=`{k}` can not be found.")
             set_node_value(node, input_path, file_name)
-        result_path = os.path.join(options.TASKS_FILES_DIR, "input", file_name)
+        result_path = os.path.join(options.INPUT_DIR, file_name)
         if isinstance(v, dict):
             if "input_index" in v:
-                input_file = os.path.join(options.TASKS_FILES_DIR, "input", f"{v['task_id']}_{v['input_index']}")
+                input_file = os.path.join(options.INPUT_DIR, f"{v['task_id']}_{v['input_index']}")
                 if not os.path.exists(input_file):
                     raise RuntimeError(
                         f"Bad flow, file from task_id=`{v['task_id']}`, index=`{v['input_index']}` not found."
@@ -440,10 +440,9 @@ def prepare_flow_comfy_files_params(
             elif "node_id" in v:
                 input_file = ""
                 result_prefix = f"{v['task_id']}_{v['node_id']}_"
-                output_directory = os.path.join(options.TASKS_FILES_DIR, "output")
-                for filename in os.listdir(output_directory):
+                for filename in os.listdir(options.OUTPUT_DIR):
                     if filename.startswith(result_prefix):
-                        input_file = os.path.join(output_directory, filename)
+                        input_file = os.path.join(options.OUTPUT_DIR, filename)
                 if not input_file or not os.path.exists(input_file):
                     raise RuntimeError(
                         f"Bad flow, file from task_id=`{v['task_id']}`, node_id={v['node_id']} not found."

--- a/visionatrix/install_update/custom_nodes.py
+++ b/visionatrix/install_update/custom_nodes.py
@@ -1,8 +1,11 @@
 import logging
 import os
 import sys
+import tempfile
 from pathlib import Path
 from subprocess import run
+
+import httpx
 
 from .. import options
 from ..basic_node_list import BASIC_NODE_LIST
@@ -11,6 +14,17 @@ LOGGER = logging.getLogger("visionatrix")
 
 
 def install_base_custom_nodes() -> None:
+    if sys.platform.lower() == "win32":
+        if sys.version_info.minor == 10:
+            install_wheel(
+                "https://github.com/Gourieff/Assets/raw/main/Insightface/insightface-0.7.3-cp310-cp310-win_amd64.whl",
+                "insightface-0.7.3-cp310-cp310-win_amd64.whl",
+            )
+        elif sys.version_info.minor == 12:
+            install_wheel(
+                "https://github.com/Gourieff/Assets/raw/main/Insightface/insightface-0.7.3-cp312-cp312-win_amd64.whl",
+                "insightface-0.7.3-cp312-cp312-win_amd64.whl",
+            )
     cm_cli_path = Path(options.COMFYUI_DIR).joinpath("custom_nodes").joinpath("ComfyUI-Manager").joinpath("cm-cli.py")
     clone_env = os.environ.copy()
     clone_env["COMFYUI_PATH"] = str(Path(options.COMFYUI_DIR).resolve())
@@ -41,3 +55,20 @@ def update_base_custom_nodes() -> None:
         env=clone_env,
         check=True,
     )
+
+
+def install_wheel(url: str, file_name: str):
+    LOGGER.info("Installing `%s`", url)
+    temp_dir = tempfile.gettempdir()
+    temp_file_path = os.path.join(temp_dir, file_name)
+    with (
+        open(temp_file_path, "wb") as temp_file,
+        httpx.stream("GET", url, follow_redirects=True, timeout=10.0) as response,
+    ):
+        response.raise_for_status()
+        for chunk in response.iter_bytes():
+            temp_file.write(chunk)
+    try:
+        run([sys.executable, "-m", "pip", "install", temp_file_path], check=True)
+    finally:
+        os.remove(temp_file_path)

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -106,7 +106,9 @@ This will enable `nextcloud` user backend in addition to the default `vix_db`.
 """
 
 
-def init_dirs_values(comfyui_dir: str, base_data_dir: str, input_dir: str, output_dir: str, user_dir: str, models_dir: str) -> None:
+def init_dirs_values(
+    comfyui_dir: str, base_data_dir: str, input_dir: str, output_dir: str, user_dir: str, models_dir: str
+) -> None:
     global COMFYUI_DIR, BASE_DATA_DIR, INPUT_DIR, OUTPUT_DIR, USER_DIR, MODELS_DIR
     if comfyui_dir:
         COMFYUI_DIR = str(Path(comfyui_dir).resolve())

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -106,24 +106,39 @@ This will enable `nextcloud` user backend in addition to the default `vix_db`.
 """
 
 
-def init_dirs_values(comfyui_dir: str, input_dir: str, output_dir: str, user_dir: str, models_dir: str) -> None:
-    global COMFYUI_DIR, INPUT_DIR, OUTPUT_DIR, USER_DIR, MODELS_DIR
+def init_dirs_values(comfyui_dir: str, base_data_dir: str, input_dir: str, output_dir: str, user_dir: str, models_dir: str) -> None:
+    global COMFYUI_DIR, BASE_DATA_DIR, INPUT_DIR, OUTPUT_DIR, USER_DIR, MODELS_DIR
     if comfyui_dir:
         COMFYUI_DIR = str(Path(comfyui_dir).resolve())
+    if base_data_dir:
+        BASE_DATA_DIR = str(Path(base_data_dir).resolve())
+
     if input_dir:
         INPUT_DIR = str(Path(input_dir).resolve())
+    elif base_data_dir:
+        INPUT_DIR = str(Path(BASE_DATA_DIR).joinpath("input").resolve())
+
     if output_dir:
         OUTPUT_DIR = str(Path(output_dir).resolve())
+    elif base_data_dir:
+        OUTPUT_DIR = str(Path(BASE_DATA_DIR).joinpath("output").resolve())
+
     if user_dir:
         USER_DIR = str(Path(user_dir).resolve())
+    elif base_data_dir:
+        USER_DIR = str(Path(BASE_DATA_DIR).joinpath("user").resolve())
+
     if models_dir:
         MODELS_DIR = str(Path(models_dir).resolve())
+    elif base_data_dir:
+        MODELS_DIR = str(Path(BASE_DATA_DIR).joinpath("models").resolve())
 
 
 def get_server_mode_options_as_env() -> dict[str, str]:
     return {
         "LOG_LEVEL": logging.getLevelName(logging.getLogger().getEffectiveLevel()),
         "COMFYUI_DIR": COMFYUI_DIR,
+        "BASE_DATA_DIR": BASE_DATA_DIR,
         "INPUT_DIR": INPUT_DIR,
         "OUTPUT_DIR": OUTPUT_DIR,
         "USER_DIR": USER_DIR,

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -11,7 +11,21 @@ load_dotenv()
 
 PYTHON_EMBEDED = path.split(path.split(sys.executable)[0])[1] == "python_embeded"
 COMFYUI_DIR = environ.get("COMFYUI_DIR", str(Path("ComfyUI") if PYTHON_EMBEDED else Path("./ComfyUI").resolve()))
-TASKS_FILES_DIR = environ.get("TASKS_FILES_DIR", str(Path("./vix_tasks_files").resolve()))
+BASE_DATA_DIR = environ.get(
+    "BASE_DATA_DIR", str(Path("ComfyUI-Data") if PYTHON_EMBEDED else Path("./ComfyUI-Data").resolve())
+)
+"""
+Base data directory for INPUT_DIR, OUTPUT_DIR, USER_DIR, MODELS_DIR.
+For customization you usually want to change only this.
+"""
+INPUT_DIR = environ.get("INPUT_DIR", str(Path(BASE_DATA_DIR).joinpath("input").resolve()))
+"""Directory to store tasks inputs."""
+OUTPUT_DIR = environ.get("OUTPUT_DIR", str(Path(BASE_DATA_DIR).joinpath("output").resolve()))
+"""Directory to store tasks outputs."""
+USER_DIR = environ.get("USER_DIR", str(Path(BASE_DATA_DIR).joinpath("user").resolve()))
+"""Directory to store config of the ComfyUI nodes."""
+MODELS_DIR = environ.get("MODELS_DIR", str(Path(BASE_DATA_DIR).joinpath("models").resolve()))
+"""Directory to store ComfyUI models."""
 
 VIX_HOST = environ.get("VIX_HOST", "")
 """Address to bind in the `DEFAULT` or `SERVER` mode."""
@@ -92,24 +106,32 @@ This will enable `nextcloud` user backend in addition to the default `vix_db`.
 """
 
 
-def init_dirs_values(comfyui: str | None, tasks_files: str | None) -> None:
-    global COMFYUI_DIR, TASKS_FILES_DIR
-    if comfyui:
-        COMFYUI_DIR = str(Path(comfyui).resolve())
-    if tasks_files:
-        TASKS_FILES_DIR = str(Path(tasks_files).resolve())
+def init_dirs_values(comfyui_dir: str, input_dir: str, output_dir: str, user_dir: str, models_dir: str) -> None:
+    global COMFYUI_DIR, INPUT_DIR, OUTPUT_DIR, USER_DIR, MODELS_DIR
+    if comfyui_dir:
+        COMFYUI_DIR = str(Path(comfyui_dir).resolve())
+    if input_dir:
+        INPUT_DIR = str(Path(input_dir).resolve())
+    if output_dir:
+        OUTPUT_DIR = str(Path(output_dir).resolve())
+    if user_dir:
+        USER_DIR = str(Path(user_dir).resolve())
+    if models_dir:
+        MODELS_DIR = str(Path(models_dir).resolve())
 
 
 def get_server_mode_options_as_env() -> dict[str, str]:
     return {
         "LOG_LEVEL": logging.getLevelName(logging.getLogger().getEffectiveLevel()),
         "COMFYUI_DIR": COMFYUI_DIR,
-        "TASKS_FILES_DIR": TASKS_FILES_DIR,
+        "INPUT_DIR": INPUT_DIR,
+        "OUTPUT_DIR": OUTPUT_DIR,
+        "USER_DIR": USER_DIR,
+        "MODELS_DIR": MODELS_DIR,
         "VIX_HOST": VIX_HOST,
         "VIX_PORT": VIX_PORT,
         "UI_DIR": UI_DIR,
         "VIX_MODE": VIX_MODE,
-        "VIX_SERVER_WORKERS": VIX_SERVER_WORKERS,
     }
 
 

--- a/visionatrix/routes/tasks.py
+++ b/visionatrix/routes/tasks.py
@@ -410,10 +410,9 @@ async def get_task_inputs(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Task `{task_id}` was not found.")
     if r["user_id"] != request.scope["user_info"].user_id and not request.scope["user_info"].is_admin:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Task `{task_id}` was not found.")
-    input_directory = os.path.join(options.TASKS_FILES_DIR, "input")
-    for filename in os.listdir(input_directory):
+    for filename in os.listdir(options.INPUT_DIR):
         if filename == r["input_files"][input_index]["file_name"]:
-            return responses.FileResponse(os.path.join(input_directory, filename))
+            return responses.FileResponse(os.path.join(options.INPUT_DIR, filename))
     raise HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=f"Task({r['task_id']}): input file `{r['input_files'][input_index]['file_name']}` was not found.",
@@ -676,7 +675,6 @@ async def set_task_results(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Task `{task_id}` was not found.")
     if task_details["user_id"] != request.scope["user_info"].user_id and not request.scope["user_info"].is_admin:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Task `{task_id}` was not found.")
-    output_directory = os.path.join(options.TASKS_FILES_DIR, "output")
     for task_output in task_details["outputs"]:
         task_file_prefix = f"{task_id}_{task_output['comfy_node_id']}_"
         relevant_files = [file_info for file_info in files if file_info.filename.startswith(task_file_prefix)]
@@ -691,7 +689,7 @@ async def set_task_results(
             file_size += i.size
             batch_size += 1
             try:
-                file_path = Path(output_directory).joinpath(i.filename)
+                file_path = Path(options.OUTPUT_DIR).joinpath(i.filename)
                 with builtins.open(file_path, mode="wb") as out_file:
                     shutil.copyfileobj(i.file, out_file)
             finally:


### PR DESCRIPTION
Now we have separated env vars:

 * `BASE_DATA_DIR`
 * `INPUT_DIR`
 * `OUTPUT_DIR`
 * `USER_DIR`
 * `MODELS_DIR`
 
 
Command line args `--tasks_files_dir` and `--comfyui_dir` were removed, as not needed.

Each env var can be specified through the database.

Migration steps for existing setups will be described here: #332