### PR TITLE
rework(internal): parallel Flows installation

### DIFF
--- a/visionatrix/_version.py
+++ b/visionatrix/_version.py
@@ -1,3 +1,3 @@
 """Version of Visionatrix"""
 
-__version__ = "1.12.0.dev0"
+__version__ = "2.0.0.dev0"

--- a/visionatrix/alembic/versions/f11111eac1d1_flows_table.py
+++ b/visionatrix/alembic/versions/f11111eac1d1_flows_table.py
@@ -1,0 +1,39 @@
+"""Flows tables
+
+Revision ID: f01666eac6d5
+Revises: 87e327306368
+Create Date: 2025-03-10 11:54:39.522692
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f11111eac1d1"
+down_revision: str | None = "90b4e0fa8d34"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "flows_install_status", sa.Column("installed", sa.Boolean(), nullable=False, server_default=sa.text("false"))
+    )
+    op.execute("UPDATE flows_install_status SET installed = true WHERE progress = 100")
+    op.drop_column("flows_install_status", "progress")
+    op.create_index(op.f("ix_flows_install_status_installed"), "flows_install_status", ["installed"], unique=False)
+    op.add_column("flows_install_status", sa.Column("models", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.add_column(
+        "flows_install_status", sa.Column("progress", sa.Float(), nullable=False, server_default=sa.text("0.0"))
+    )
+    op.execute("UPDATE flows_install_status SET progress = 100 WHERE installed = true")
+    op.execute("UPDATE flows_install_status SET progress = 0 WHERE installed = false")
+    op.drop_index(op.f("ix_flows_install_status_installed"), table_name="flows_install_status")
+    op.drop_column("flows_install_status", "installed")
+    op.drop_column("flows_install_status", "models")

--- a/visionatrix/database.py
+++ b/visionatrix/database.py
@@ -145,10 +145,11 @@ class FlowsInstallStatus(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(String, nullable=False, unique=True)
     flow_comfy = Column(JSON, default={}, nullable=False)
-    progress = Column(Float, default=0.0, nullable=False)
     error = Column(String, default="")
     started_at = Column(DateTime, default=datetime.now(timezone.utc), nullable=False)
     updated_at = Column(DateTime, default=datetime.now(timezone.utc), nullable=False)
+    installed = Column(Boolean, default=False, nullable=False)
+    models = Column(JSON, nullable=True)
 
 
 class ModelsInstallStatus(Base):

--- a/visionatrix/db_queries.py
+++ b/visionatrix/db_queries.py
@@ -631,4 +631,4 @@ async def _compute_flow_progress(flow_status, session) -> float:
     model_progresses = (await session.execute(query_models)).scalars().all()
     if not model_progresses:
         return 0.0
-    return min(99.0, sum(model_progresses) / len(model_progresses))
+    return min(99.0, sum(model_progresses) / len(models_list))

--- a/visionatrix/pydantic_models.py
+++ b/visionatrix/pydantic_models.py
@@ -186,6 +186,12 @@ class FlowProgressInstall(BaseModel):
     started_at: datetime = Field(..., description="Timestamp when the installation process started.")
     updated_at: datetime = Field(..., description="Timestamp of the last update to the installation progress.")
 
+    @classmethod
+    def from_orm_with_progress(cls, orm_obj, progress: float) -> Self:
+        data = orm_obj.__dict__.copy()
+        data["progress"] = progress
+        return cls.model_validate(data)
+
     @field_validator("name", mode="after")
     @classmethod
     def lowercase_name(cls, value: str) -> str:


### PR DESCRIPTION
During the recent testing of the first docker images on https://novite.ai - it was discovered that sometimes when installing several flows in parallel using the same models - the installation progress could go beyond 100%, and sometimes fail, which led to unnecessary model reloading.

The algorithm was refactored, since now we have a table with models (it did not exist before when the original algorithm was written), - it was made so that the backend calculates the flow installation progress by it, and does not store/update it in the database in parallel from several flows.

In theory, it should become simpler and better.