### PR TITLE
move visionatrix results to Comfy's output subfolder

### DIFF
--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -412,9 +412,10 @@ def prepare_flow_comfy_files_params(
             elif "node_id" in v:
                 input_file = ""
                 result_prefix = f"{v['task_id']}_{v['node_id']}_"
-                for filename in os.listdir(options.OUTPUT_DIR):
+                visionatrix_output_dir = os.path.join(options.OUTPUT_DIR, "visionatrix")
+                for filename in os.listdir(visionatrix_output_dir):
                     if filename.startswith(result_prefix):
-                        input_file = os.path.join(options.OUTPUT_DIR, filename)
+                        input_file = os.path.join(visionatrix_output_dir, filename)
                 if not input_file or not os.path.exists(input_file):
                     raise RuntimeError(
                         f"Bad flow, file from task_id=`{v['task_id']}`, node_id={v['node_id']} not found."
@@ -490,9 +491,9 @@ def flow_prepare_output_params(
                 f"class_type={r_node['class_type']}: only {supported_outputs} nodes are supported currently as outputs"
             )
         if r_node["class_type"] == "SaveText|pysssss":
-            r_node["inputs"]["file"] = f"{task_id}_{param}_.txt"
+            r_node["inputs"]["file"] = f"visionatrix/{task_id}_{param}_.txt"
         else:
-            r_node["inputs"]["filename_prefix"] = f"{task_id}_{param}"
+            r_node["inputs"]["filename_prefix"] = f"visionatrix/{task_id}_{param}"
         task_details["outputs"].append(
             {
                 "comfy_node_id": int(param),

--- a/visionatrix/routes/tasks.py
+++ b/visionatrix/routes/tasks.py
@@ -689,7 +689,7 @@ async def set_task_results(
             file_size += i.size
             batch_size += 1
             try:
-                file_path = Path(options.OUTPUT_DIR).joinpath(i.filename)
+                file_path = Path(options.OUTPUT_DIR).joinpath("visionatrix").joinpath(i.filename)
                 with builtins.open(file_path, mode="wb") as out_file:
                     shutil.copyfileobj(i.file, out_file)
             finally:

--- a/visionatrix/tasks_engine.py
+++ b/visionatrix/tasks_engine.py
@@ -367,7 +367,7 @@ async def remove_unfinished_tasks_by_name_and_group(name: str, user_id: str, gro
 
 def get_task_files(task_id: int, directory: typing.Literal["input", "output"]) -> list[tuple[str, str]]:
     result_prefix = str(task_id) + "_"
-    target_directory = options.INPUT_DIR if directory == "input" else options.OUTPUT_DIR
+    target_directory = options.INPUT_DIR if directory == "input" else os.path.join(options.OUTPUT_DIR, "visionatrix")
     r = []
     for filename in sorted(os.listdir(target_directory)):
         if filename.startswith(result_prefix):
@@ -381,7 +381,7 @@ def remove_task_files(task_id: int, directories: list[str]) -> None:
         if directory == "input":
             target_directory = options.INPUT_DIR
         elif directory == "output":
-            target_directory = options.OUTPUT_DIR
+            target_directory = os.path.join(options.OUTPUT_DIR, "visionatrix")
         else:
             raise ValueError(f"Invalid input value: {directory}")
         for filename in os.listdir(target_directory):


### PR DESCRIPTION
Old variant how output files were stored:

`ComfyUI-Data/output/12_00018_.png` - Visionatrix result
`ComfyUI-Data/output/ComfyUI_00102_.png` - ComfyUI result

All was in the same folder - that is not convenient, as they were mixed.

With this PR:

`ComfyUI-Data/output/visionatrix/12_00018_.png` - Visionatrix result
`ComfyUI-Data/output/ComfyUI_00102_.png - ComfyUI result

All results of Visionatrix now stored in the `visionatrix` sub-folder.

**Migration of files is done automatically and included in this PR.**