### PR TITLE
feat: save input files with their extension

### DIFF
--- a/visionatrix/routes/tasks_internal.py
+++ b/visionatrix/routes/tasks_internal.py
@@ -183,10 +183,12 @@ async def process_string_value(request: Request, user_id: str, key: str, value: 
     if "remote_url" in input_file_info:
         await process_remote_input_url(request, input_file_info)
     elif "task_id" in input_file_info:
-        if not await get_task_async(int(input_file_info["task_id"]), user_id):
+        task_info = await get_task_async(int(input_file_info["task_id"]), user_id)
+        if not task_info:
             raise HTTPException(
                 status.HTTP_400_BAD_REQUEST, detail=f"Missing task with id={input_file_info['task_id']}"
             ) from None
+        input_file_info["task_info"] = task_info
     else:
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST, detail="Missing `task_id` or `remote_url` parameter."


### PR DESCRIPTION
From the first versions of Visionatrix we were saving input files like this:

`11_input_image`
`677_person_face`

This PR changes that now also the extension is stored:

`1035_person_face.png`
`1049_person_face.jpg`

Also, this PR probably fixes the logic(**it was broken**) when someone will want to create a task from the input of other already existing task(we do not support that in UI currently, so I tested with `curl`)