### PR TITLE
fix: deploying on Novita.a/RunPodi;optimized Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,32 +22,32 @@ run:
 .PHONY: push-cpu
 push-cpu:
 	docker login ghcr.io
-	docker buildx build --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:release-cpu --build-arg BUILD_TYPE=cpu -f docker/Dockerfile .
+	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:release-cpu --build-arg BUILD_TYPE=cpu -f docker/Dockerfile .
 
 .PHONY: push-latest-cpu
 push-latest-cpu:
 	docker login ghcr.io
-	docker buildx build --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:latest-cpu --build-arg BUILD_TYPE=cpu -f docker/Dockerfile .
+	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:latest-cpu --build-arg BUILD_TYPE=cpu -f docker/Dockerfile .
 
 .PHONY: push-cuda
 push-cuda:
 	docker login ghcr.io
-	docker buildx build --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:release-cuda --build-arg BUILD_TYPE=cuda -f docker/Dockerfile .
+	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:release-cuda --build-arg BUILD_TYPE=cuda -f docker/Dockerfile .
 
 .PHONY: push-latest-cuda
 push-latest-cuda:
 	docker login ghcr.io
-	docker buildx build --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:latest-cuda --build-arg BUILD_TYPE=cuda -f docker/Dockerfile .
+	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:latest-cuda --build-arg BUILD_TYPE=cuda -f docker/Dockerfile .
 
 .PHONY: push-rocm
 push-rocm:
 	docker login ghcr.io
-	docker buildx build --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:release-rocm --build-arg BUILD_TYPE=rocm -f docker/Dockerfile .
+	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:release-rocm --build-arg BUILD_TYPE=rocm -f docker/Dockerfile .
 
 .PHONY: push-latest-rocm
 push-latest-rocm:
 	docker login ghcr.io
-	docker buildx build --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:latest-rocm --build-arg BUILD_TYPE=rocm -f docker/Dockerfile .
+	DOCKER_BUILDKIT=1 docker buildx build --progress=plain --push --platform linux/amd64 --tag ghcr.io/visionatrix/visionatrix:latest-rocm --build-arg BUILD_TYPE=rocm -f docker/Dockerfile .
 
 .PHONY: openapi
 openapi:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,45 +1,47 @@
 FROM python:3.12-slim
 
-ENV VIX_HOST="127.0.0.1"
-ENV VIX_PORT=8288
-ENV DATABASE_URI="sqlite+aiosqlite:////data/visionatrix.db"
-ENV BASE_DATA_DIR="/data"
+ENV VIX_HOST="127.0.0.1" \
+    VIX_PORT=8288 \
+    DATABASE_URI="sqlite+aiosqlite:////data/visionatrix.db" \
+    BASE_DATA_DIR="/data"
+
 ARG BUILD_TYPE
 
-VOLUME ["/data"]
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y wget curl git \
-	python3-dev python3-setuptools netcat-traditional \
-	libxml2-dev libxslt1-dev zlib1g-dev g++ \
-	ffmpeg libsm6 libxext6 lshw procps libpq-dev libpq5
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      wget curl git \
+      python3-dev python3-setuptools netcat-traditional \
+      libxml2-dev libxslt1-dev zlib1g-dev g++ \
+      ffmpeg libsm6 libxext6 lshw procps libpq-dev libpq5 && \
+    rm -rf /var/lib/apt/lists/*
 
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m venv venv && \
+    set -eux; \
+    if [ "$BUILD_TYPE" = "cuda" ]; then \
+      venv/bin/python -m pip install torch torchaudio torchvision --extra-index-url https://download.pytorch.org/whl/cu126; \
+    elif [ "$BUILD_TYPE" = "rocm" ]; then \
+      venv/bin/python -m pip install torch torchaudio torchvision --index-url https://download.pytorch.org/whl/rocm6.2.4; \
+    elif [ "$BUILD_TYPE" = "cpu" ]; then \
+      venv/bin/python -m pip install torch torchaudio torchvision --index-url https://download.pytorch.org/whl/cpu; \
+    else \
+      echo "Unsupported BUILD_TYPE: $BUILD_TYPE" && exit 1; \
+    fi
 
-RUN python3 -m venv venv \
-    && venv/bin/python -m pip install -U pip \
-    && set -eux; \
-       if [ "$BUILD_TYPE" = "cuda" ]; then \
-         venv/bin/python -m pip install torch torchaudio torchvision --extra-index-url https://download.pytorch.org/whl/cu126; \
-       elif [ "$BUILD_TYPE" = "rocm" ]; then \
-         venv/bin/python -m pip install torch torchaudio torchvision --index-url https://download.pytorch.org/whl/rocm6.2.4; \
-       elif [ "$BUILD_TYPE" = "cpu" ]; then \
-         venv/bin/python -m pip install torch torchaudio torchvision --index-url https://download.pytorch.org/whl/cpu; \
-       else \
-         echo "Unsupported BUILD_TYPE: $BUILD_TYPE"; exit 1; \
-       fi \
-    && rm -rf ~/.cache/pip
-
-COPY visionatrix /app/visionatrix
 COPY LICENSE.txt README.md pyproject.toml /app/
+COPY visionatrix /app/visionatrix
 
 COPY ./docker/entrypoint.sh /entrypoint.sh
 COPY ./docker/healthcheck.sh /healthcheck.sh
 RUN chmod +x /entrypoint.sh /healthcheck.sh
 
-RUN venv/bin/python -m pip install ".[pgsql]" \
-    && mkdir ./tmp \
-	&& DATABASE_URI="sqlite+aiosqlite:///./tmp/visionatrix.db" BASE_DATA_DIR="./tmp" venv/bin/python -m visionatrix install \
-    && rm -rf ./tmp visionatrix ~/.cache/pip
+RUN --mount=type=cache,target=/root/.cache/pip \
+    venv/bin/python -m pip install -U pip && \
+    venv/bin/python -m pip install ".[pgsql]" && \
+    mkdir tmp && \
+    DATABASE_URI="sqlite+aiosqlite:///./tmp/visionatrix.db" BASE_DATA_DIR="./tmp" venv/bin/python -m visionatrix install && \
+    rm -rf tmp visionatrix
 
 HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=18 CMD /healthcheck.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Today, when I was testing the docker image deployment, I realized that it doesn't work on [Novita.ai](https://novita.ai) - because we have `VOLUME ["/data"]` defined in our Dockerfile - which causes an error, if do not setup such volume manually(which will be strange to do).

This should be fixed with this PR, tested it with [latest-cuda](https://github.com/Visionatrix/Visionatrix/pkgs/container/visionatrix/382333739?tag=latest-cuda) images that I'd already pushed.

Also added `DOCKER_BUILDKIT=1` to greatly speed up building of docker images by using docker cache.