### PR TITLE
webhooks: custom logic when "x-transport-uds" key is present in webhook's headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,6 @@ build-client-nextcloud:
 	@rm -rf visionatrix/client && rm -rf web/.output/public/
 	@cd web && NUXT_APP_BASE_URL=/index.php/apps/app_api/proxy/visionatrix/ NEXTCLOUD_INTEGRATION=true npm run build && \
 		cp -r .output/public ../visionatrix/client
+	@rm -rf web/.output/public/
+	@cd web && NUXT_APP_BASE_URL=/exapps/visionatrix/ NEXTCLOUD_INTEGRATION=true npm run build && \
+		cp -r .output/public ../visionatrix/client_harp

--- a/visionatrix/webhooks.py
+++ b/visionatrix/webhooks.py
@@ -9,7 +9,11 @@ async def webhook_task_progress(
     url: str, headers: dict | None, task_id: int, progress: float, execution_time: float, error: str
 ) -> None:
     try:
-        async with httpx.AsyncClient(base_url=url, timeout=3.0) as client:
+        transport = None
+        if headers and "x-transport-uds" in headers:
+            transport = httpx.AsyncHTTPTransport(uds=headers["x-transport-uds"])
+            headers.pop("x-transport-uds")
+        async with httpx.AsyncClient(base_url=url, timeout=3.0, transport=transport) as client:
             await client.post(
                 url="task-progress",
                 json={


### PR DESCRIPTION
Nextcloud switches to HaRP from version 32, and there applications listen to a `Unix socket`, not a `host:port`.

Let's add that if there is a custom header, it contains the name of this socket file, so as not to add a new field to the task_details table (it is already huge).