### PR TITLE
(fix): incorrect logging level when run through "uvicorn"

### DIFF
--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -20,7 +20,7 @@ from . import (
     update_pip_auto_fix_requirements,
 )
 from .db_queries import get_all_global_settings, get_global_setting, set_global_setting
-from .etc import get_higher_log_level, get_log_level
+from .etc import setup_logging
 from .flows import get_not_installed_flows, get_vix_flow, install_custom_flow
 from .orphan_models import process_orphan_models
 
@@ -138,15 +138,7 @@ if __name__ == "__main__":
             comfyui_wrapper.add_arguments(subparser)
 
     args = parser.parse_args()
-
-    defined_loglvl = get_log_level(args.verbose)
-    logging.basicConfig(
-        level=defined_loglvl,
-        format="%(asctime)s: [%(funcName)s]:%(levelname)s: %(message)s",
-        datefmt="%H:%M:%S",
-    )
-    logging.getLogger("httpx").setLevel(get_higher_log_level(defined_loglvl))
-    logging.getLogger("alembic").setLevel(get_higher_log_level(defined_loglvl))
+    setup_logging(log_level_name=args.verbose)
 
     if args.command == "run":
         if args.host:

--- a/visionatrix/install_update/install_update.py
+++ b/visionatrix/install_update/install_update.py
@@ -32,7 +32,7 @@ def install() -> None:
         LOGGER.info("Removing existing ComfyUI directory: %s", comfyui_dir)
         rmtree(comfyui_dir, onerror=remove_readonly)
     os.makedirs(comfyui_dir)
-    logging.info("Installing ComfyUI..")
+    LOGGER.info("Installing ComfyUI..")
     check_call(["git", "clone", "https://github.com/comfyanonymous/ComfyUI.git", comfyui_dir])
     if not dev_release:
         clone_env = os.environ.copy()
@@ -44,7 +44,7 @@ def install() -> None:
     )
     create_nodes_stuff()
     comfyui_manager_path = Path(comfyui_dir).joinpath("custom_nodes").joinpath("ComfyUI-Manager")
-    logging.info("Installing ComfyUI-Manager..")
+    LOGGER.info("Installing ComfyUI-Manager..")
     check_call(["git", "clone", "https://github.com/ltdrdata/ComfyUI-Manager.git", comfyui_manager_path])
     if not dev_release:
         clone_env = os.environ.copy()
@@ -68,7 +68,7 @@ def install() -> None:
 
 
 def update() -> None:
-    logging.info("Updating ComfyUI..")
+    LOGGER.info("Updating ComfyUI..")
     dev_release = Version(_version.__version__).is_devrelease
     comfyui_dir = Path(options.COMFYUI_DIR)
     requirements_path = os.path.join(comfyui_dir, "requirements.txt")
@@ -78,7 +78,7 @@ def update() -> None:
         try:
             check_call(["git", "pull"], cwd=comfyui_dir)
         except CalledProcessError:
-            logging.error("git pull for '%s' folder failed. Trying apply the `rebase` flag..", comfyui_dir)
+            LOGGER.error("git pull for '%s' folder failed. Trying apply the `rebase` flag..", comfyui_dir)
             check_call(["git", "pull", "--rebase"], cwd=comfyui_dir)
     else:
         check_call(["git", "fetch", "--all"], cwd=comfyui_dir)
@@ -93,7 +93,7 @@ def update() -> None:
         )
     create_nodes_stuff()
     comfyui_manager_path = Path(comfyui_dir).joinpath("custom_nodes").joinpath("ComfyUI-Manager")
-    logging.info("Updating ComfyUI-Manager..")
+    LOGGER.info("Updating ComfyUI-Manager..")
     requirements_path = os.path.join(comfyui_manager_path, "requirements.txt")
     old_requirements = Path(requirements_path).read_text(encoding="utf-8")
     if dev_release:
@@ -101,7 +101,7 @@ def update() -> None:
         try:
             check_call(["git", "pull"], cwd=comfyui_manager_path)
         except CalledProcessError:
-            logging.error("git pull for '%s' folder failed. Trying apply the `rebase` flag..", comfyui_manager_path)
+            LOGGER.error("git pull for '%s' folder failed. Trying apply the `rebase` flag..", comfyui_manager_path)
             check_call(["git", "pull", "--rebase"], cwd=comfyui_manager_path)
     else:
         check_call(["git", "fetch", "--all"], cwd=comfyui_manager_path)
@@ -116,7 +116,7 @@ def update() -> None:
         check_call(
             [sys.executable, "-m", "pip", "install", "-r", os.path.join(comfyui_manager_path, "requirements.txt")],
         )
-    logging.info("Updating custom nodes..")
+    LOGGER.info("Updating custom nodes..")
     update_base_custom_nodes()
     # Temporary workarounds
     run(
@@ -125,14 +125,14 @@ def update() -> None:
     )
     # ======
     asyncio.run(comfyui_wrapper.load(None))
-    logging.info("Updating flows..")
+    LOGGER.info("Updating flows..")
     avail_flows_comfy = {}
     avail_flows = asyncio.run(get_available_flows(avail_flows_comfy))
     for i in asyncio.run(get_installed_flows()):
         if i in avail_flows:
             asyncio.run(install_custom_flow(avail_flows[i], avail_flows_comfy[i]))
         else:
-            logging.warning("`%s` flow not found in repository, skipping update of it.", i)
+            LOGGER.warning("`%s` flow not found in repository, skipping update of it.", i)
 
 
 def create_nodes_stuff() -> None:

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -1,6 +1,5 @@
 """Options to change Visionatrix runtime behavior."""
 
-import logging
 import sys
 from os import environ, path
 from pathlib import Path
@@ -153,7 +152,6 @@ def init_dirs_values(
 
 def get_server_mode_options_as_env() -> dict[str, str]:
     return {
-        "LOG_LEVEL": logging.getLevelName(logging.getLogger().getEffectiveLevel()),
         "COMFYUI_DIR": COMFYUI_DIR,
         "BASE_DATA_DIR": BASE_DATA_DIR,
         "INPUT_DIR": INPUT_DIR,


### PR DESCRIPTION
 Logging levels set via `LOG_LEVEL` or `--verbose` were ignored when running the server with multiple workers (`VIX_SERVER_WORKERS=2`), causing `INFO`/`DEBUG` logs to be missed.

Solution:
- Created a central `setup_logging` function for all logging configuration.
- Call `setup_logging` from `__main__.py` (for direct commands) and within the FastAPI `lifespan` (for Uvicorn workers).

This ensures consistent logging behavior and correct level application across all supported run commands, including direct `uvicorn` invocation(`LOG_LEVEL=WARNING uvicorn --port=8288 --workers=4 visionatrix:APP`).