### PR TITLE
Bug fixes pull request

### DIFF
--- a/visionatrix/backend.py
+++ b/visionatrix/backend.py
@@ -232,6 +232,11 @@ def run_vix(*args, **kwargs) -> None:
     for filename in os.listdir(options.OUTPUT_DIR):
         file_path = os.path.join(options.OUTPUT_DIR, filename)
         if os.path.isfile(file_path) and (pattern_default.match(filename) or pattern_mp4.match(filename)):
+            # remote the destination file if it exists
+            destination_file = os.path.join(destination, filename)
+            if os.path.exists(destination_file):
+                os.remove(destination_file)
+            # Move the file to the destination directory
             shutil.move(file_path, destination)
             copied_files += 1
 

--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -506,6 +506,7 @@ def flow_prepare_output_params(
             "ShowText|pysssss",
             "MathExpression|pysssss",
             "PreviewImage",
+            "Image Comparer (rgthree)",
         ):
             continue
         supported_outputs = SUPPORTED_OUTPUTS.keys()

--- a/visionatrix/models.py
+++ b/visionatrix/models.py
@@ -267,8 +267,12 @@ def get_model_total_size(response: httpx.Response) -> int:
             raise RuntimeError("Server did not provide 'Content-Range' header for partial content.")
         total_size = int(content_range.split("/")[-1])
     else:
-        total_size = int(response.headers.get("Content-Length", 0))
-
+        # fix for some servers that do not provide Content-Length header for full content
+        if "Content-Length" not in response.headers:
+            # Guess the total size based on the size of the response body
+            total_size = 10 * 1024 * 1024
+        else:
+            total_size = int(response.headers.get("Content-Length", 0))
     if not total_size:
         raise RuntimeError("Received empty response when attempting to download the model.")
     return total_size


### PR DESCRIPTION
I found 3 bugs in my windows11 after learning and testing.

1. Can't move \output\xxx.png to \output\visionatrix\xxx.png if \output\visionatrix\xxx.png is existed.
2. Not Content-Length in response header when download model (such as download https://hf-mirror.com/andrey18106/visionatrix_models/resolve/main/mmdet/bbox/mmdet_anime-face_yolov3.py)
3. Add "Image Comparer (rgthree)" for output nodes check.

BR. Eric
China