### PR TITLE
fix: flows: memory requirements; correctly set is_supported_by_workers field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - UI: Updated packages to last versions. #373
 - Much more advanced parallel model loading/flows install algorithm. #362
 - Deselecting LoRA from the existing flow now correctly allows to save the modified flow. #361
+- Adjusted memory requirements to mark flows as supported; UI correctly displays advanced options when `is_seed_supported=False`. #381
 - The log level is now set correctly when Visionatrix is started directly from `uvicorn`. #366
 - Now when running Visionatrix directly from `uvicorn` the correct values settings are read from the database. #369
 

--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -758,14 +758,14 @@ def is_flow_supported(flow: Flow, available_workers: list[WorkerDetails]) -> boo
     if flow.is_macos_supported is False and not any(worker.device_type != "mps" for worker in available_workers):
         return False
     if flow.required_memory_gb:
-        required_memory_bytes = flow.required_memory_gb * 1024 * 1024 * 1000  # GPU sometimes have less mem
+        required_memory_bytes = flow.required_memory_gb * 1024 * 1024 * 980  # GPU sometimes have less mem
         return any(worker.vram_total >= required_memory_bytes for worker in available_workers)
     return True
 
 
 def fill_flows_supported_field(flows: dict[str, Flow], available_workers: list[WorkerDetails]) -> dict[str, Flow]:
     for flow in flows.values():
-        flow.is_seed_supported = is_flow_supported(flow, available_workers)
+        flow.is_supported_by_workers = is_flow_supported(flow, available_workers)
     return flows
 
 


### PR DESCRIPTION
1. There was a typo where the `fill_flows_supported_field` function filled `is_seed_supported` instead of `is_supported_by_workers`
2. `pytorch` sometimes returns `vram_total` for the 4060 Ti Super as `15.47` GB - adjusted the coefficient so that it was counted as a 16GB card and 16GB flows were marked as supported on such cards.