### PR TITLE
remove was-node-suite from the default nodes

### DIFF
--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -89,7 +89,6 @@ BASIC_NODE_LIST = {
     "comfyui_ipadapter_plus@2.0.0": {},
     "comfyui_controlnet_aux@1.0.7": {},
     "skimmed_cfg@1.0.0": {},
-    "was-node-suite-comfyui@1.0.2": {},
     "comfyui-visionatrix@1.2.1": {},
     "comfyui-remotevae@1.0.0": {},
     "comfyui-gemini@1.0.4": {},


### PR DESCRIPTION
This node has **too high start time** impact and we do not use anything from it in our flows.

_We will try step-by-step to remove all non-needed nodes and freeze the python dependencies version list to increase security level._

**Those who have WAS Node Suite installed already still will be able to use it.** 
It will be removed only for the new installations.
