### PR TITLE
chore: refactore __main__.py to use async

### DIFF
--- a/visionatrix/custom_openapi.py
+++ b/visionatrix/custom_openapi.py
@@ -1,4 +1,3 @@
-import asyncio
 import hashlib
 import re
 from typing import Annotated
@@ -138,25 +137,25 @@ def create_dynamic_route(flow_definition: Flow):
     return dynamic_route
 
 
-def generate_openapi(app: FastAPI, flows: str = "", skip_not_installed: bool = True, exclude_base: bool = False):
+async def generate_openapi(app: FastAPI, flows: str = "", skip_not_installed: bool = True, exclude_base: bool = False):
     flows_definitions = {}
     if flows == "":
         # Do not include any flows
         flows_definitions = {}
     elif flows == "*":
         # Include all installed flows
-        flows_definitions.update(asyncio.run(get_installed_flows()))
+        flows_definitions.update(await get_installed_flows())
         if not skip_not_installed:
-            flows_definitions.update(asyncio.run(get_available_flows()))
+            flows_definitions.update(await get_available_flows())
     else:
         # flows is a comma-separated list of flow names
         flow_names = [name.strip() for name in flows.split(",") if name.strip()]
         # Get installed flows matching these names
-        installed_flows = asyncio.run(get_installed_flows())
+        installed_flows = await get_installed_flows()
         selected_flows = {name: flow for name, flow in installed_flows.items() if name in flow_names}
         if not skip_not_installed:
             # Include not installed flows if any of the specified flows are not installed
-            available_flows = asyncio.run(get_available_flows())
+            available_flows = await get_available_flows()
             for name in flow_names:
                 if name not in selected_flows and name in available_flows:
                     selected_flows[name] = available_flows[name]

--- a/visionatrix/database.py
+++ b/visionatrix/database.py
@@ -211,6 +211,7 @@ async def init_database_engine() -> None:
             database_uri = (
                 f"sqlite+aiosqlite:///{os.path.abspath(os.path.join(os.getcwd(), database_uri[len(local_dir) - 1:]))}"
             )
+        LOGGER.info("SQLite file in use: %s", database_uri)
 
     engine = create_async_engine(database_uri, connect_args=connect_args)
 

--- a/visionatrix/database.py
+++ b/visionatrix/database.py
@@ -211,7 +211,7 @@ async def init_database_engine() -> None:
             database_uri = (
                 f"sqlite+aiosqlite:///{os.path.abspath(os.path.join(os.getcwd(), database_uri[len(local_dir) - 1:]))}"
             )
-        LOGGER.info("SQLite file in use: %s", database_uri)
+        LOGGER.debug("SQLite file in use: %s", database_uri)
 
     engine = create_async_engine(database_uri, connect_args=connect_args)
 

--- a/visionatrix/install_update/install_update.py
+++ b/visionatrix/install_update/install_update.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib.metadata
 import logging
 import os
@@ -67,7 +66,7 @@ def install() -> None:
     # ======
 
 
-def update() -> None:
+async def update() -> None:
     LOGGER.info("Updating ComfyUI..")
     dev_release = Version(_version.__version__).is_devrelease
     comfyui_dir = Path(options.COMFYUI_DIR)
@@ -124,13 +123,13 @@ def update() -> None:
         check=True,
     )
     # ======
-    asyncio.run(comfyui_wrapper.load(None))
+    await comfyui_wrapper.load(None)
     LOGGER.info("Updating flows..")
     avail_flows_comfy = {}
-    avail_flows = asyncio.run(get_available_flows(avail_flows_comfy))
-    for i in asyncio.run(get_installed_flows()):
+    avail_flows = await get_available_flows(avail_flows_comfy)
+    for i in await get_installed_flows():
         if i in avail_flows:
-            asyncio.run(install_custom_flow(avail_flows[i], avail_flows_comfy[i]))
+            await install_custom_flow(avail_flows[i], avail_flows_comfy[i])
         else:
             LOGGER.warning("`%s` flow not found in repository, skipping update of it.", i)
 

--- a/visionatrix/orphan_models.py
+++ b/visionatrix/orphan_models.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from datetime import datetime
 from pathlib import Path
@@ -102,12 +101,12 @@ async def remove_orphan_model(orphan_path: str) -> bool:
     return bool(r)
 
 
-def process_orphan_models(dry_run: bool, no_confirm: bool, include_useful_models: bool) -> None:
-    if asyncio.run(db_queries.models_installation_in_progress()):
+async def process_orphan_models(dry_run: bool, no_confirm: bool, include_useful_models: bool) -> None:
+    if await db_queries.models_installation_in_progress():
         print("Some models have the status of being installed. Repeat the request in 3 minutes.")
         return
 
-    orphan_models = asyncio.run(get_orphan_models())
+    orphan_models = await get_orphan_models()
     if not include_useful_models:
         orphan_models = [model for model in orphan_models if not model.possible_flows]
 
@@ -135,7 +134,7 @@ def process_orphan_models(dry_run: bool, no_confirm: bool, include_useful_models
             continue
         if no_confirm:
             try:
-                asyncio.run(remove_orphan_model(orphan.path))
+                await remove_orphan_model(orphan.path)
                 print(f"Deleted: {orphan.path}")
             except Exception as e:
                 print(f"Error deleting {orphan.path}: {e}")
@@ -143,7 +142,7 @@ def process_orphan_models(dry_run: bool, no_confirm: bool, include_useful_models
             user_input = input(f"Delete {orphan.path}? (y/Y to confirm, any other key to skip): ").lower()
             if user_input == "y":
                 try:
-                    asyncio.run(remove_orphan_model(orphan.path))
+                    await remove_orphan_model(orphan.path)
                     print(f"Deleted: {orphan.path}")
                 except Exception as e:
                     print(f"Error deleting {orphan.path}: {e}")


### PR DESCRIPTION
Refactor the startup/runtime flow so only a single asyncio.run() call is executed.

**FastAPI**/**Uvicorn** now run entirely inside one event loop instead of spawning nested loops.

* Removed all secondary `asyncio.run() `usages.
* Introduced a single `asyncio.run(main())` entry-point.
* Re-wired Uvicorn startup to use its awaitable API (`server = uvicorn.Server(config); await server.serve()`).
* Added async OpenAPI route replacement (`/openapi.json`) and disabled the built-in schema path to avoid conflicts.
* Fixed a rare case where the list of installed flows was sometimes empty on startup. **This also caused errors in CI.**