### PR TITLE
fix(ComfyUI logs): remove unnecessary code

### DIFF
--- a/visionatrix/comfyui_wrapper.py
+++ b/visionatrix/comfyui_wrapper.py
@@ -11,7 +11,6 @@ import contextlib
 import enum
 import gc
 import importlib.util
-import inspect
 import logging
 import os
 import subprocess
@@ -115,20 +114,7 @@ async def load(
     folder_paths.set_input_directory(str(Path(options.INPUT_DIR)))
     folder_paths.set_user_directory(str(Path(options.USER_DIR)))
 
-    original_add_handler = logging.Logger.addHandler
-
-    def out_add_handler(self, hdlr):
-        stack = inspect.stack()  # Get the current stack frames
-        if any(frame.function == "setup_logger" for frame in stack):
-            return  # Skip adding handler (prevent duplicate logs)
-        original_add_handler(self, hdlr)  # Call the original addHandler method
-
-    logging.Logger.addHandler = out_add_handler
-
     import main  # noqa # isort: skip
-
-    logging.Logger.addHandler = original_add_handler
-
     import execution  # noqa # isort: skip
     import nodes  # noqa # isort: skip
     import server  # noqa # isort: skip


### PR DESCRIPTION
From quick look - it was changed here:

https://github.com/comfyanonymous/ComfyUI/pull/6243

Before that PR we were needed our code to prevent ComfyUI's logs appear twice in output.

But now our code just hides ComfyUI logs and they are not visible at all, so it is not a workaround anymore, but rather a bug.

Good that we can remove it 😎