### PR TITLE
feat(integrations): env var to exclude available flows

### DIFF
--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -143,6 +143,13 @@ async def __fetch_and_merge_all_flows(
             if flow_name not in combined_flows or parse(flow_obj.version) > parse(combined_flows[flow_name].version):
                 combined_flows[flow_name] = flow_obj
                 combined_flows_comfy[flow_name] = flows_comfy_dict[flow_name]
+
+    if options.EXCLUDE_FLOWS_SET:
+        for flow_id in list(combined_flows.keys()):
+            if flow_id.lower() in options.EXCLUDE_FLOWS_SET:
+                combined_flows.pop(flow_id, None)
+                combined_flows_comfy.pop(flow_id, None)
+
     return combined_flows, combined_flows_comfy, new_per_storage
 
 

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -114,6 +114,11 @@ INSTALL_EXCLUDE_NODES_SET = {
 }
 """List of custom node names(separated by ';') to exclude during installation."""
 
+EXCLUDE_FLOWS_SET: set[str] = {
+    flow_id.strip().lower() for flow_id in environ.get("VISIONATRIX_EXCLUDE_FLOWS", "").split(";") if flow_id.strip()
+}
+"""List of flow IDs(separated by ';') to exclude from available-flows."""
+
 
 def get_admin_override_credentials() -> tuple[str, str] | None:
     if ":" not in ADMIN_OVERRIDE:


### PR DESCRIPTION
In addition to #393 where we had introduced ability for integrations to exclude nodes from the default installation, we now also add the ability to exclude default flows.

*It will cost too much time to support a fully separate list of Flows for NC(at least for now), so we will just hide some flows that can not be executed by integration, that **has limited nodes set***.