### PR TITLE
feat: AUTH to be controlled by separate ENV variable (RunPOD tempalte)

### DIFF
--- a/visionatrix/_version.py
+++ b/visionatrix/_version.py
@@ -1,3 +1,3 @@
 """Version of Visionatrix"""
 
-__version__ = "2.3.1.dev0"
+__version__ = "2.4.0.dev0"

--- a/visionatrix/backend.py
+++ b/visionatrix/backend.py
@@ -54,9 +54,9 @@ class VixAuthMiddleware:
     async def _handle_http(self, scope: Scope, receive: Receive, send: Send) -> None:
         conn = HTTPConnection(scope)
         url_path = conn.url.path.lstrip("/")
-        if options.VIX_MODE == "DEFAULT":
+        if not options.AUTH_ENABLED:
             scope["user_info"] = database.DEFAULT_USER
-        elif not fnmatch.filter(self._disable_for, url_path):
+        elif not any(fnmatch.fnmatch(url_path, i) for i in self._disable_for):
             userinfo = self._check_admin_override_auth(conn.headers)
             if userinfo:
                 scope["user_info"] = userinfo
@@ -80,9 +80,9 @@ class VixAuthMiddleware:
 
     async def _handle_websocket(self, scope: Scope, receive: Receive, send: Send) -> None:
         url_path = scope.get("path", "").lstrip("/")
-        if options.VIX_MODE == "DEFAULT":
+        if not options.AUTH_ENABLED:
             scope["user_info"] = database.DEFAULT_USER
-        elif not fnmatch.filter(self._disable_for, url_path):
+        elif not any(fnmatch.fnmatch(url_path, i) for i in self._disable_for):
             headers_dict, cookies_dict = parse_cookies_and_headers(scope)
             userinfo = self._check_admin_override_auth(headers_dict)
             if userinfo:

--- a/visionatrix/options.py
+++ b/visionatrix/options.py
@@ -34,9 +34,22 @@ VIX_PORT = environ.get("VIX_PORT", "")
 UI_DIR = environ.get("UI_DIR", "")
 VIX_MODE = environ.get("VIX_MODE", "DEFAULT")
 """
-* DEFAULT - storage and delivery of tasks(Server) + tasks processing(Worker), authentication is disabled.
-* SERVER - only storage and managing of tasks, authentication is enabled, requires PgSQL database.
+* DEFAULT - storage and delivery of tasks(Server) + tasks processing(Worker).
+* SERVER - only storage and managing of tasks.
 * WORKER - only processing tasks for the Server(client consuming mode, no backend)
+"""
+
+AUTH_ENABLED = int(environ.get("VIX_AUTH", "0"))
+"""
+Whether authentication is enabled. By default (`0`), authentication is disabled!
+Set to `1` to enable authentication, especially recommended for remote or shared deployments.
+"""
+
+AUTH_ADMIN_OVERRIDE = environ.get("VIX_AUTH_ADMIN_OVERRIDE", "admin2:admin2")
+"""
+Used only when authentication is enabled.
+If set, this should be in the format "username:password".
+The specified user is treated as admin without requiring database record (useful for headless setups or initial access).
 """
 
 VIX_SERVER = environ.get("VIX_SERVER", "")
@@ -104,11 +117,6 @@ Example:
 This will enable `nextcloud` user backend in addition to the default `vix_db`.
 """
 
-ADMIN_OVERRIDE = environ.get("ADMIN_OVERRIDE", "")
-"""If set, should contain something like "admin:pass",
-and it is considered as an admin user (emulated, without actual DB record).
-"""
-
 INSTALL_EXCLUDE_NODES_SET = {
     node.strip() for node in environ.get("VISIONATRIX_INSTALL_EXCLUDE_NODES", "").split(";") if node.strip()
 }
@@ -121,9 +129,9 @@ EXCLUDE_FLOWS_SET: set[str] = {
 
 
 def get_admin_override_credentials() -> tuple[str, str] | None:
-    if ":" not in ADMIN_OVERRIDE:
+    if ":" not in AUTH_ADMIN_OVERRIDE:
         return None
-    user, password = ADMIN_OVERRIDE.split(":", 1)
+    user, password = AUTH_ADMIN_OVERRIDE.split(":", 1)
     user, password = user.strip(), password.strip()
     if not user or not password:
         return None


### PR DESCRIPTION
I tried today to make a public templates for **RunPod** and stuck with situation, where we should use `DEFAULT` mode for easy deployment, but with the enabled authentication.

In this PR we introduce a new variable to control whether authentication is enabled or disabled.
From now the `DEFAULT` or `SERVER` modes can be with authentication or not.

Also we rename `ADMIN_OVERRIDE` to `AUTH_ADMIN_OVERRIDE` for explicit showing to which part of Visionatrix it is related.


P.S: changes in the `fnmatch.filter` part of auth part described here: https://github.com/cloud-py-api/nc_py_api/pull/357 - but we do not use that part in Visionatrix currently, so it is not a critical bug.
