### PR TITLE
chore: drop rgthree-comfy node from the basic nodes list

### DIFF
--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -97,9 +97,6 @@ BASIC_NODE_LIST = {
     "comfyui_essentials": {
         "version": "1.1.0",
     },
-    "rgthree-comfy": {
-        "version": "1.0.0",
-    },
     "comfyui-custom-scripts": {
         "version": "1.2.3",
     },


### PR DESCRIPTION
This node does not support versioning in Comfy registry(it has constant version `1.0.0`) and we do not use it. 

Who still needs it, can install it from the ComfyUI-Manager