### PR TITLE
feat(llm): use gemma3:12b-it-qat as default ollama model instead of qwen2.5:14b

### DIFF
--- a/visionatrix/prompt_translation.py
+++ b/visionatrix/prompt_translation.py
@@ -28,7 +28,7 @@ async def translate_prompt_with_ollama(
         ollama_url = None
     if not ollama_llm_model:
         LOGGER.debug("No custom Ollama LLM model defined, trying default one.")
-        ollama_llm_model = "qwen2.5:14b"
+        ollama_llm_model = "gemma3:12b-it-qat"
 
     system_prompt = LLM_TRANSLATE_SYSTEM_PROMPT if data.system_prompt is None else data.system_prompt
 

--- a/visionatrix/surprise_me.py
+++ b/visionatrix/surprise_me.py
@@ -481,7 +481,7 @@ async def surprise_me(
             ollama_url = None
         ollama_llm_model = await get_setting(user_id, "ollama_llm_model", is_admin)
         if not ollama_llm_model:
-            ollama_llm_model = "qwen2.5:14b"
+            ollama_llm_model = "gemma3:12b-it-qat"
         ollama_keepalive = await get_setting(user_id, "ollama_keepalive", is_admin)
         if ollama_keepalive:
             ollama_keepalive += "m"


### PR DESCRIPTION
Today I tested it in different situations, it seems to be very good and multimodal, suitable for 16GB cards.

I also checked `gemma3:27b-it-qat` - it fits easily into a 24GB card, for those who have a 24GB card for Ollama - use the bigger one version of course.

Will make a PR with flows so that it is now there by default as well.