### PR TITLE
chore: drop ComfyUI_FizzNodes node

### DIFF
--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -174,9 +174,6 @@ BASIC_NODE_LIST = {
     "https://github.com/kaibioinfo/ComfyUI_AdvancedRefluxControl": {
         "version": "",
     },
-    "https://github.com/FizzleDorf/ComfyUI_FizzNodes": {
-        "version": "",
-    },
     "https://github.com/ZenAI-Vietnam/ComfyUI_InfiniteYou": {
         "version": "",
         "models": [ANTELOPEV2],


### PR DESCRIPTION
As described [here](https://github.com/Visionatrix/VixFlowsDocs/pull/109), we cannot use `ComfyUI_FizzNodes` as it has a node with `class_type="StringConcatenate"` and recently a node with the same name was added to Comfy Core and this leads to conflicts as `ComfyUI_FizzNodes` overwrites the base ComfyUI node.

Flow `AllYourLife` was removed as it will take too much time to rewrite it without `ComfyUI_FizzNodes`
Flow `PhotoStickers 2` was adopted to work without `ComfyUI_FizzNodes`