### PR TITLE
chore: drop comfyui-frame-interpolation node

### DIFF
--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -133,9 +133,6 @@ BASIC_NODE_LIST = {
     "comfyui-videohelpersuite": {
         "version": "1.6.1",
     },
-    "comfyui-frame-interpolation": {
-        "version": "1.0.7",
-    },
     "comfyui-kjnodes": {
         "version": "1.1.0",
     },


### PR DESCRIPTION
It was used only in AllYourLife flow, so no more needed in bundle - who needs always can install it from ComfyUI-Manager