### PR TITLE
fix(gemini-node): set GOOGLE_API_KEY env var, instead of using api_key input

### DIFF
--- a/visionatrix/basic_node_list.py
+++ b/visionatrix/basic_node_list.py
@@ -116,7 +116,7 @@ BASIC_NODE_LIST = {
         "version": "1.0.0",
     },
     "comfyui-gemini": {
-        "version": "1.0.4",
+        "version": "1.0.5",
     },
     "comfyui-ollama": {
         "version": "2.0.3",

--- a/visionatrix/tasks_engine.py
+++ b/visionatrix/tasks_engine.py
@@ -126,10 +126,11 @@ async def get_incomplete_task_without_error(last_task_name: str) -> dict:
         gemini_model = await get_worker_value("GEMINI_MODEL", task_to_exec["user_id"])
         for node in google_nodes:
             if google_api_key:
-                task_to_exec["flow_comfy"][node]["inputs"]["api_key"] = google_api_key
+                os.environ["GOOGLE_API_KEY"] = google_api_key
+            if google_proxy:
                 task_to_exec["flow_comfy"][node]["inputs"]["proxy"] = google_proxy
-                if gemini_model:
-                    task_to_exec["flow_comfy"][node]["inputs"]["model"] = gemini_model
+            if gemini_model:
+                task_to_exec["flow_comfy"][node]["inputs"]["model"] = gemini_model
 
     remote_vae_switches = get_remote_vae_switches(task_to_exec["flow_comfy"])
     if remote_vae_switches:


### PR DESCRIPTION
Support of this was fixed in the Gemini node today: https://github.com/Visionatrix/ComfyUI-Gemini/commit/fe559461db4beeef59f2147d7eecd0cf9da36e1a

This will allow to enable "Save metadata" and to not expose Google API key when you share pictures where ComfyUI workflows are embedded.
Also this will allow to use "Comfy flow" download button in Visionatrix and to safely share flow with someone without manually removing Google API key from it.