### PR TITLE
fix(makefile): use sed for version extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-VISIONATRIX_VERSION := $(shell grep -Po '(?<=__version__ = ")[^"]*' visionatrix/_version.py)
+VISIONATRIX_VERSION := $(shell sed -n "s/^__version__ = ['\"]\([^'\"]*\)['\"]/\1/p" visionatrix/_version.py)
 
 ifeq ($(VISIONATRIX_VERSION),)
 $(error Could not extract version from visionatrix/_version.py. Please check the file.)


### PR DESCRIPTION
I'm getting `grep: invalid option -- P` error with default grep 2.6.0 on macOS. Use `sed` instead.