### PR TITLE
chore: update windows-2019 -> windows-2022 runner

### DIFF
--- a/.github/workflows/embedded-windows.yml
+++ b/.github/workflows/embedded-windows.yml
@@ -16,9 +16,9 @@ env:
   BUILD_RELEASE: 1
 
 jobs:
-  windows_2019_cuda:
-    name: Windows:2019-x86_64-CUDA
-    runs-on: windows-2019
+  windows_2022_cuda:
+    name: Windows:2022-x86_64-CUDA
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4
@@ -100,7 +100,7 @@ jobs:
           if-no-files-found: error
 
   publish_release:
-    needs: [windows_2019_cuda]
+    needs: [windows_2022_cuda]
     name: Publish release
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/tests-flows-run.yml
+++ b/.github/workflows/tests-flows-run.yml
@@ -116,8 +116,8 @@ jobs:
         run: python3 tests/rm_background.py
 
   github_flows_run_windows:
-    name: Flows Run GitHub Windows 2019
-    runs-on: windows-2019
+    name: Flows Run GitHub Windows 2022
+    runs-on: windows-2022
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Upgrading `windows-2019` runner (support ends on June 30) to `windows-2022`. 