### PR TITLE
fix(WindowsPortable): manually pre-install "filterpy" in actions

### DIFF
--- a/.github/workflows/embedded-windows.yml
+++ b/.github/workflows/embedded-windows.yml
@@ -38,6 +38,7 @@ jobs:
           curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
           ./python.exe get-pip.py
           ./python.exe -m pip install hatchling Cython
+          ./python.exe -m pip install git+https://github.com/rodjjo/filterpy.git
           cd ../..
 
       - name: Install Vix

--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ We offer a **portable version** to simplify installation (no need for Git or Vis
 
 Currently, we provide versions for CUDA/CPU. If there's demand, we can add a DirectML version.
 
-1. **Download**: Visit our [Releases page](https://github.com/Visionatrix/Visionatrix/releases).
-2. **Get the Portable Archive**: Download `vix_portable_cuda.7z`.
-3. **Unpack and Run**: Extract the archive and run `run_nvidia_gpu.bat` or `run_cpu.bat`.
+1. **Install VC++ Redistributable**: *vc_redist.x64.exe* from this [Microsoft page](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version).
+2. **Download**: Visit our [Releases page](https://github.com/Visionatrix/Visionatrix/releases).
+3. **Get the Portable Archive**: Download `vix_portable_cuda.7z`.
+4. **Unpack and Run**: Extract the archive and run `run_nvidia_gpu.bat` or `run_cpu.bat`.
 
 ### Manual Installation
 


### PR DESCRIPTION
And mention in the Readme that `VC++ redist` should be installed on Windows.

Advice on how to install `filterpy` was taken from [here](https://github.com/lldacing/ComfyUI_PuLID_Flux_ll/issues/47#issuecomment-2704902441)