### PR TITLE
feat(docker): use all CUDA GPUs available by default

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,9 +32,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 COPY LICENSE.txt README.md pyproject.toml /app/
 COPY visionatrix /app/visionatrix
 
-COPY ./docker/entrypoint.sh /entrypoint.sh
+COPY ./docker/entrypoint.py /entrypoint.py
 COPY ./docker/healthcheck.sh /healthcheck.sh
-RUN chmod +x /entrypoint.sh /healthcheck.sh
+RUN chmod +x /entrypoint.py /healthcheck.sh
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     venv/bin/python -m pip install -U pip && \
@@ -44,4 +44,4 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     rm -rf tmp visionatrix
 
 HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=18 CMD /healthcheck.sh
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/app/venv/bin/python", "/entrypoint.py"]

--- a/docker/entrypoint.py
+++ b/docker/entrypoint.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+import time
+
+import torch
+
+
+def launch_workers_and_ui():
+    if os.environ.get("SKIP_MULTIPLE_WORKERS") or not torch.cuda.is_available():
+        cmd = [sys.executable, "-m", "visionatrix", "run", "--ui"]
+        os.execvpe(cmd[0], cmd, os.environ)
+
+    total_gpus = torch.cuda.device_count()
+    print(f"Detected {total_gpus} GPU(s).", flush=True)
+
+    if total_gpus < 1:
+        print("No GPUs found despite CUDA being available. Launching UI on CPU.", flush=True)
+        cmd = [sys.executable, "-m", "visionatrix", "run", "--ui"]
+        os.execvpe(cmd[0], cmd, os.environ)
+
+    for idx in range(1, total_gpus):
+        print(f"Launching WORKER on GPU {idx}.", flush=True)
+        env_worker = os.environ.copy()
+        env_worker["CUDA_VISIBLE_DEVICES"] = str(idx)
+        worker_cmd = [sys.executable, "-m", "visionatrix", "run", "--mode=WORKER"]
+        subprocess.Popen(worker_cmd, env=env_worker)
+        print("Sleeping for 15 seconds before next launch...", flush=True)
+        time.sleep(15)
+
+    print("Launching Visionatrix on GPU 0.", flush=True)
+    env_ui = os.environ.copy()
+    env_ui["CUDA_VISIBLE_DEVICES"] = "0"
+    ui_cmd = [sys.executable, "-m", "visionatrix", "run", "--ui"]
+    os.execvpe(ui_cmd[0], ui_cmd, env_ui)
+
+
+if __name__ == "__main__":
+    launch_workers_and_ui()

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-/app/venv/bin/python -m visionatrix run --ui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,9 @@ lint.extend-ignore = [
   "SIM117",
 ]
 
+lint.per-file-ignores."docker/entrypoint.py" = [
+  "S606",
+]
 lint.per-file-ignores."scripts/*.*" = [
   "E402",
   "S602",


### PR DESCRIPTION
In this PR, we replace the `entrypoint.sh` script in our Docker images - which previously only executed `python -m visionatrix run --ui` - with a Python script that launches additional workers if more than one CUDA device is available.

This has been tested on RunPOD with 2x3090 GPUs, and the deployed container is now able to utilize multiple GPUs.

*This behavior can be disabled by setting the `SKIP_MULTIPLE_WORKERS` environment variable, for rare cases where multi-GPU usage is not desired.*

Additionally, this PR **fixes** incorrect GPU index reporting from workers to the server. Previously, the code always reported the index as `0`, even when `CUDA_VISIBLE_DEVICES=2` was set. This was because PyTorch assigns local indices starting from `0`, regardless of the system-wide GPU index. Our old code reported the PyTorch-local index (`0`) instead of the actual mapped system index (`2`). This is now corrected.
