### PR TITLE
feat(workers): pre-init comfyui engine global settings on startup

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2267,6 +2267,45 @@
         }
       }
     },
+    "/vapi/workers/default_engine_settings": {
+      "get": {
+        "tags": [
+          "workers"
+        ],
+        "summary": "Default Engine Settings",
+        "description": "Route only for remote workers. Returns default configured values for the ComfyUI engine.",
+        "operationId": "default_engine_settings",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      }
+                    ]
+                  },
+                  "type": "object",
+                  "title": "Response Default Engine Settings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/vapi/federation/instances": {
       "get": {
         "tags": [
@@ -4882,7 +4921,7 @@
             "format": "date-time",
             "title": "Last Seen",
             "description": "Last seen time",
-            "default": "2025-06-07T06:26:32.511334Z"
+            "default": "2025-06-21T13:07:18.517725Z"
           },
           "engine_details": {
             "$ref": "#/components/schemas/ComfyEngineDetails"

--- a/visionatrix/comfyui_wrapper.py
+++ b/visionatrix/comfyui_wrapper.py
@@ -19,6 +19,7 @@ import threading
 import time
 import typing
 import uuid
+from collections.abc import Awaitable, Callable
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from socket import gethostname
@@ -391,7 +392,11 @@ def need_cpu_flag() -> bool:
     return True
 
 
-def background_prompt_executor_comfy(prompt_executor_args: tuple | list, exit_event: threading.Event):
+def background_prompt_executor_comfy(
+    prompt_executor_args: tuple | list,
+    exit_event: threading.Event,
+    initialize_comfyui_engine_settings: Callable[[], Awaitable[None]],
+):
     global PROMPT_EXECUTOR
 
     import comfy  # noqa
@@ -402,6 +407,7 @@ def background_prompt_executor_comfy(prompt_executor_args: tuple | list, exit_ev
 
     current_time: float = 0.0
     PROMPT_EXECUTOR = execution.PromptExecutor(prompt_server, cache_type=execution.CacheType.CLASSIC, cache_size=0)
+    asyncio.run(initialize_comfyui_engine_settings())
     last_gc_collect = 0
     need_gc = False
     gc_collect_interval = 10.0

--- a/visionatrix/db_queries.py
+++ b/visionatrix/db_queries.py
@@ -210,7 +210,7 @@ async def get_all_system_settings() -> dict[str, str]:
             raise
 
 
-async def get_all_global_settings_for_task_execution() -> dict[str, bool | int | str]:
+async def get_all_global_settings_for_task_execution() -> dict[str, bool | int | str | float]:
     """Retrieve all global settings related to task execution to init the ExtraFlags model."""
     async with database.SESSION() as session:
         try:

--- a/visionatrix/routes/workers.py
+++ b/visionatrix/routes/workers.py
@@ -2,7 +2,11 @@ import logging
 
 from fastapi import APIRouter, Body, HTTPException, Query, Request, responses, status
 
-from ..db_queries import get_workers_details, save_worker_settings
+from ..db_queries import (
+    get_all_global_settings_for_task_execution,
+    get_workers_details,
+    save_worker_settings,
+)
 from ..pydantic_models import WorkerDetails, WorkerSettingsRequest
 
 LOGGER = logging.getLogger("visionatrix")
@@ -49,3 +53,13 @@ async def set_worker_settings(request: Request, data: WorkerSettingsRequest = Bo
     user_id = None if request.scope["user_info"].is_admin else request.scope["user_info"].user_id
     if not await save_worker_settings(user_id, data):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Can't find `{data.worker_id}` worker.")
+
+
+@ROUTER.get(
+    "/default_engine_settings",
+    response_class=responses.JSONResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def default_engine_settings() -> dict[str, bool | int | str | float]:
+    """Route only for remote workers. Returns default configured values for the ComfyUI engine."""
+    return await get_all_global_settings_for_task_execution()

--- a/visionatrix/tasks_engine.py
+++ b/visionatrix/tasks_engine.py
@@ -37,6 +37,7 @@ from .tasks_engine_etc import (
     TASK_DETAILS_COLUMNS,
     TASK_DETAILS_COLUMNS_SHORT,
     get_incomplete_task_without_error_query,
+    initialize_comfyui_engine_settings,
     nodes_execution_profiler,
     prepare_worker_info_update,
 )
@@ -775,7 +776,9 @@ def background_prompt_executor(prompt_executor_args: tuple | list, exit_event: t
     last_task_name = ""
 
     threading.Thread(
-        target=comfyui_wrapper.background_prompt_executor_comfy, args=(prompt_executor_args, exit_event), daemon=True
+        target=comfyui_wrapper.background_prompt_executor_comfy,
+        args=(prompt_executor_args, exit_event, initialize_comfyui_engine_settings),
+        daemon=True,
     ).start()
 
     q = prompt_executor_args[0]


### PR DESCRIPTION
Found today that this is needed during developing the new Flow with new model.

This help in situations, when you want to use ComfyUI UI from the Visionatrix, but without first executing Visionatrix tasks the ComfyUI's Engine values does not get initialized.
Executing each time first an any task for Visionatrix allows to grab those values(like `reserve_vram` or `smart_memory`), but still does not convenient.

_note: this is initialized with global default values, so does not work for `custom overriding for specific worker` to not get algorithm too over-complicated._