### PR TITLE
fix(update): restart the process after installing the new basic python packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ lint.per-file-ignores."scripts/*.*" = [
 lint.per-file-ignores."visionatrix/__init__.py" = [
   "F401",
 ]
+lint.per-file-ignores."visionatrix/__main__.py" = [
+  "S606",
+]
 lint.per-file-ignores."visionatrix/backend.py" = [
   "C901",
 ]

--- a/visionatrix/__main__.py
+++ b/visionatrix/__main__.py
@@ -50,6 +50,9 @@ def _build_parser() -> argparse.ArgumentParser:
         ("set-global-setting", "Create or update a global setting"),
     ]:
         subparser = subparsers.add_parser(i[0], help=i[1])
+        if i[0] == "update":
+            subparser.add_argument("--stage-2", action="store_true", help=argparse.SUPPRESS)
+
         if i[0] == "create-user":
             subparser.add_argument("--name", type=str, help="User name(ID)", required=True)
             subparser.add_argument("--password", type=str, help="User password", required=True)
@@ -254,7 +257,16 @@ async def main() -> int:
                     return 0
         install()
     elif args.command == "update":
-        await update()
+        if await update(stage_2=args.stage_2):
+            new_args = [sys.executable]
+            if __package__:
+                new_args.extend(["-m", __package__])
+                new_args.extend(sys.argv[1:])
+            else:
+                new_args.extend(sys.argv)
+            if "--stage-2" not in new_args:
+                new_args.append("--stage-2")
+            os.execv(new_args[0], new_args)
     elif args.command == "run":
         await run_vix()
     elif args.command == "install-flow":


### PR DESCRIPTION
If the `aiohttp` package is updated in ComfyUI, and we update ComfyUI and after updating the package we do not restart the current process, then the update ends with an error (repeated update ends successfully)

In theory, this PR fix this situation, if new packages were installed in ComfyUI or ComfyUI-Manager, then the Visionatrix updater will restart itself after their installation and continue from the place where it finished updating further