### PR TITLE
fix(modify-flow): use "VixMultilineText" instead of "Text Multiline" which is missing by default

### DIFF
--- a/visionatrix/flows.py
+++ b/visionatrix/flows.py
@@ -630,7 +630,7 @@ def get_flow_metadata(flow_comfy: dict[str, dict]) -> dict[str, str | list | dic
                 if value := node_details["inputs"].get(i):
                     r[i] = json.loads(value)
             return r
-        if node_details.get("_meta", {}).get("title", "") == "WF_META":  # Text Multiline (Code Compatible)
+        if node_details.get("_meta", {}).get("title", "") == "WF_META":  # Text Multiline
             return json.loads(node_details["inputs"]["text"])
     raise ValueError("ComfyUI flow should contain Workflow metadata")
 

--- a/visionatrix/flows_loras.py
+++ b/visionatrix/flows_loras.py
@@ -162,7 +162,7 @@ async def flow_add_model(flow_comfy: dict[str, dict], civitai_model_url: str, ty
         wf_models_node_id = str(max(int(k) for k in flow_comfy) + 1)
         flow_comfy[wf_models_node_id] = {
             "inputs": {"text": "{}"},
-            "class_type": "Text Multiline (Code Compatible)",
+            "class_type": "VixMultilineText",
             "_meta": {"title": "WF_MODELS"},
         }
 

--- a/visionatrix/models_map.py
+++ b/visionatrix/models_map.py
@@ -463,6 +463,6 @@ def get_simple_model_load_classes(models_catalog: dict[str, dict]) -> dict[str, 
 
 def get_embedded_models_catalog(flow_comfy: dict[str, dict]) -> dict[str, dict]:
     for node_details in flow_comfy.values():
-        if node_details.get("_meta", {}).get("title", "") == "WF_MODELS":  # Text Multiline (Code Compatible)
+        if node_details.get("_meta", {}).get("title", "") == "WF_MODELS":  # Text Multiline
             return json.loads(node_details["inputs"]["text"])
     return {}


### PR DESCRIPTION
By default, in the latest released version, we don't have the "Text Multiline (Code Compatible)" node for new installations, but it was still used by the backend to determine which models the workflow uses, and flows created from UI with new LoRAs on the new installations fails to execute.

_I forgot to change this when we threw out the WAS Node Suite nodepack - from the default nodes and this PR fixes this, we will use our "VixMultilineText" node instead of "Text Multiline (Code Compatible)"._