### PR TITLE
fix(update-process): fixed typo that was breaking updating between release versions

### DIFF
--- a/visionatrix/install_update/install_update.py
+++ b/visionatrix/install_update/install_update.py
@@ -88,7 +88,7 @@ async def update(stage_2: bool = False) -> bool:
             clone_env = os.environ.copy()
             clone_env["GIT_CONFIG_PARAMETERS"] = "'advice.detachedHead=false'"
             check_call(
-                ["git", "checkout", f"tags/{basic_node_list.COMFYUI_MANAGER_RELEASE_TAG}"],
+                ["git", "checkout", f"tags/{basic_node_list.COMFYUI_RELEASE_TAG}"],
                 env=clone_env,
                 cwd=comfyui_dir,
             )


### PR DESCRIPTION
This is a very old typo, but as we do not use `release` versions it was not noticed - just spotted it randomly.

_p.s: a good idea is to add CI test after next release to check this algo automatically (or to ask ComfyUI to release ComfyUI as a python package)_